### PR TITLE
Use non-alpha eslint pre-commit version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
 
   # Lint: JS code
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: "v9.0.0-alpha.0" # Use the sha / tag you want to point at
+    rev: "v8.56.0" # Use the sha / tag you want to point at
     hooks:
       - id: eslint
         files: \.jsx?$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,8 @@ repos:
         types: [file]
         exclude: jupyterhub_fancy_profiles/static
         additional_dependencies:
-          # Duplicated from package.json's devDependencies
+          # Duplicated from package.json's devDependencies, otherwise pre-commit.ci
+          # does not like it
           - eslint
           - eslint-plugin-react
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,9 @@ repos:
         files: \.jsx?$
         types: [file]
         exclude: jupyterhub_fancy_profiles/static
+        additional_dependencies:
+          # Duplicated from package.json's devDependencies
+          - eslint-plugin-react
 
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
         exclude: jupyterhub_fancy_profiles/static
         additional_dependencies:
           # Duplicated from package.json's devDependencies
+          - eslint
           - eslint-plugin-react
 
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration


### PR DESCRIPTION
The alpha version, automatically provided to us by the pre-commit.ci bump, does not seem to actually work