### PR TITLE
Include built files in sdist / wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft jupyterhub_fancy_profiles/static/dist


### PR DESCRIPTION
Without this, the built files are not included in the PyPI package