### PR TITLE
Update styling of profile display + description

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -46,8 +46,8 @@ setup_ui(c)
 # Provide an example profile with various options in use
 c.KubeSpawner.profile_list = [
     {
-        "display_name": "Small",
-        "description": "~2 CPU, ~2G RAM",
+        "display_name": "CPU only usage",
+        "description": "For use with just CPU, no GPU",
         "profile_options": {
             "image": {
                 "display_name": "Image",

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -133,5 +133,94 @@ c.KubeSpawner.profile_list = [
                 },
             },
         },
-    }
+    },
+    {
+        "display_name": "GPU only usage",
+        "description": "for use with GPU",
+        "profile_options": {
+            "image": {
+                "display_name": "Image",
+                "unlisted_choice": {
+                    "enabled": True,
+                    "display_name": "Custom image",
+                    "validation_regex": "^.+:.+$",
+                    "validation_message": "Must be a publicly available docker image, of form <image-name>:<tag>",
+                    "display_name_in_choices": "Specify an existing docker image",
+                    "description_in_choices": "Use a pre-existing docker image from a public docker registry",
+                    "kubespawner_override": {"image": "{value}"},
+                },
+                "choices": {
+                    "pangeo": {
+                        "display_name": "Pangeo Notebook Image",
+                        "description": "Python image with scientific, dask and geospatial tools",
+                        "kubespawner_override": {
+                            "image": "pangeo/pangeo-notebook:2023.09.11"
+                        },
+                    },
+                    "geospatial": {
+                        "display_name": "Rocker Geospatial",
+                        "description": "R image with RStudio, the tidyverse & Geospatial tools",
+                        "default": True,
+                        "slug": "geospatial",
+                        "kubespawner_override": {
+                            "image": "rocker/binder:4.3",
+                            "default_url": "/rstudio",
+                            "working_dir": "/home/rstudio",
+                        },
+                    },
+                    "scipy": {
+                        "display_name": "Jupyter SciPy Notebook",
+                        "slug": "scipy",
+                        "kubespawner_override": {
+                            "image": "jupyter/scipy-notebook:2023-06-26"
+                        },
+                    },
+                },
+            },
+            "resources": {
+                "display_name": "Resource Allocation",
+                "choices": {
+                    "mem_2_7": {
+                        "display_name": "2.7 GB RAM, upto 3.479 CPUs",
+                        "description": "Use this for the workshop on 2023 September",
+                        "kubespawner_override": {
+                            "mem_guarantee": 1024,
+                            "mem_limit": 2904451072,
+                            "cpu_guarantee": 0.1,
+                            "cpu_limit": 3.479,
+                        },
+                        "default": True,
+                    },
+                    "mem_5_4": {
+                        "display_name": "5.4 GB RAM, upto 3.479 CPUs",
+                        "kubespawner_override": {
+                            "mem_guarantee": 1024,
+                            "mem_limit": 5808902144,
+                            "cpu_guarantee": 0.1,
+                            "cpu_limit": 3.479,
+                        },
+                    },
+                    "mem_10_8": {
+                        "display_name": "10.8 GB RAM, upto 3.479 CPUs",
+                        "kubespawner_override": {
+                            "mem_guarantee": 1024,
+                            "mem_limit": 11617804288,
+                            "cpu_guarantee": 0.1,
+                            "cpu_limit": 3.479,
+                        },
+                    },
+                    "mem_21_6": {
+                        "display_name": "21.6 GB RAM, upto 3.479 CPUs",
+                        "description": "Large amount of RAM, might start slowly",
+                        "kubespawner_override": {
+                            "mem_guarantee": 1024,
+                            "mem_limit": 23235608576,
+                            "cpu_guarantee": 0.1,
+                            "cpu_limit": 3.479,
+                        },
+                    },
+                },
+            },
+        },
+    },
 ]

--- a/setupTests.js
+++ b/setupTests.js
@@ -2,9 +2,9 @@ import "@testing-library/jest-dom";
 
 window.profileList = [
   {
-    slug: "small",
-    display_name: "Small",
-    description: "~2 CPU, ~2G RAM",
+    slug: "cpu",
+    display_name: "CPU only",
+    description: "No GPU, only CPU",
     profile_options: {
       image: {
         display_name: "Image",
@@ -96,12 +96,12 @@ window.profileList = [
     },
   },
   {
-    slug: "big",
-    display_name: "Big",
-    description: "~16 CPU, ~512G RAM",
+    slug: "gpu",
+    display_name: "GPU",
+    description: "Nvidia Tesla T4 GPU",
     profile_options: {
       image: {
-        display_name: "Image - Big",
+        display_name: "Image - GPU",
         choices: {
           pangeo: {
             display_name: "Pangeo Notebook Image",
@@ -133,7 +133,7 @@ window.profileList = [
         },
       },
       resources: {
-        display_name: "Resource Allocation - Big",
+        display_name: "Resource Allocation - GPU",
         choices: {
           mem_2_7: {
             display_name: "3.7 GB RAM, upto 4.479 CPUs",

--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -69,8 +69,12 @@ function Form() {
                 onChange={handleProfileSelect}
                 required
               />
-              <label htmlFor={`profile-option-${slug}`}>
-                {display_name} ({description})
+              <label
+                htmlFor={`profile-option-${slug}`}
+                className="profile-select-label"
+              >
+                <h4>{display_name}</h4>
+                {description}
               </label>
             </div>
             <ProfileOptions profile={slug} config={profile_options} />

--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -60,24 +60,25 @@ function Form() {
 
         return (
           <div key={slug} className="profile-select">
-            <div className="profile-select-radio">
-              <input
-                type="radio"
-                name="select-profile"
-                id={`profile-option-${slug}`}
-                value={slug}
-                onChange={handleProfileSelect}
-                required
-              />
+            <input
+              type="radio"
+              name="select-profile"
+              id={`profile-option-${slug}`}
+              value={slug}
+              onChange={handleProfileSelect}
+              required
+            />
+            <div className="profile-select-body">
               <label
                 htmlFor={`profile-option-${slug}`}
                 className="profile-select-label"
               >
                 <h4>{display_name}</h4>
-                {description}
+                <p>{description}</p>
               </label>
+
+              <ProfileOptions profile={slug} config={profile_options} />
             </div>
-            <ProfileOptions profile={slug} config={profile_options} />
           </div>
         );
       })}

--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -73,8 +73,10 @@ function Form() {
                 htmlFor={`profile-option-${slug}`}
                 className="profile-select-label"
               >
-                <h4>{display_name}</h4>
-                <p>{description}</p>
+                <span className="profile-select-label-heading">
+                  {display_name}
+                </span>
+                <span>{description}</span>
               </label>
 
               <ProfileOptions profile={slug} config={profile_options} />

--- a/src/ProfileForm.test.js
+++ b/src/ProfileForm.test.js
@@ -28,7 +28,9 @@ test("image and resource fields tabable", async () => {
     </SpawnerFormProvider>,
   );
 
-  const radio = screen.getByRole("radio", { name: "Small (~2 CPU, ~2G RAM)" });
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
   await user.click(radio);
 
   const imageField = screen.getByLabelText("Image");
@@ -47,7 +49,9 @@ test("custom image field is required", async () => {
     </SpawnerFormProvider>,
   );
 
-  const radio = screen.getByRole("radio", { name: "Small (~2 CPU, ~2G RAM)" });
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
   await user.click(radio);
 
   const imageField = screen.getByLabelText("Image");
@@ -70,7 +74,9 @@ test("custom image field needs specific format", async () => {
     </SpawnerFormProvider>,
   );
 
-  const radio = screen.getByRole("radio", { name: "Small (~2 CPU, ~2G RAM)" });
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
   await user.click(radio);
 
   const imageField = screen.getByLabelText("Image");
@@ -97,7 +103,9 @@ test("custom image field accepts specific format", async () => {
     </SpawnerFormProvider>,
   );
 
-  const radio = screen.getByRole("radio", { name: "Small (~2 CPU, ~2G RAM)" });
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
   await user.click(radio);
 
   const imageField = screen.getByLabelText("Image");
@@ -125,11 +133,11 @@ test("Multiple profiles renders", async () => {
     </SpawnerFormProvider>,
   );
 
-  const radio = screen.getByRole("radio", { name: "Big (~16 CPU, ~512G RAM)" });
+  const radio = screen.getByRole("radio", { name: "GPU Nvidia Tesla T4 GPU" });
   await user.click(radio);
 
-  expect(screen.getByLabelText("Image - Big").tabIndex).toEqual(0);
-  expect(screen.getByLabelText("Resource Allocation - Big").tabIndex).toEqual(
+  expect(screen.getByLabelText("Image - GPU").tabIndex).toEqual(0);
+  expect(screen.getByLabelText("Resource Allocation - GPU").tabIndex).toEqual(
     0,
   );
 

--- a/src/form.css
+++ b/src/form.css
@@ -9,6 +9,10 @@
   margin-bottom: 5rem;
 }
 
+.profile-select-label {
+  font-weight: normal;
+}
+
 .profile-select-radio {
   display: flex;
   gap: 1rem;

--- a/src/form.css
+++ b/src/form.css
@@ -21,6 +21,12 @@
   margin-bottom: 1rem;
 }
 
+.profile-select-label-heading {
+  display: block;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
 .profile-select-radio {
   display: flex;
   gap: 1rem;

--- a/src/form.css
+++ b/src/form.css
@@ -7,10 +7,18 @@
 
 .profile-select {
   margin-bottom: 5rem;
+  display: flex;
+  flex-direction: row;
+  border-bottom: 1px solid #ccc;
 }
 
-.profile-select-label {
+.profile-select-body {
+  margin-left: 3rem;
+}
+
+.profile-select-body label {
   font-weight: normal;
+  margin-bottom: 1rem;
 }
 
 .profile-select-radio {
@@ -33,8 +41,6 @@
 .profile-option-label-container {
   grid-column-start: 1;
   align-self: start;
-  justify-self: right;
-  text-align: right;
 }
 
 .profile-option-control-container {


### PR DESCRIPTION
Looks like this now:

<img width="1001" alt="image" src="https://github.com/yuvipanda/jupyterhub-fancy-profiles/assets/30430/33287fd3-2fa2-4a8b-b12b-2ff5c5ac5bd0">

Used to look like:

<img width="1176" alt="image" src="https://github.com/yuvipanda/jupyterhub-fancy-profiles/assets/30430/4e4b3517-0dc5-4866-94e7-2614e0c175bf">

Changes:

1. Radio button is vertically centered in the profile
2. Profile display name is a `<h4>`, and the description (if present) is rendered as a `<p>`, instead of being in parantheses.
3. Small bottom border to differentiate between profiles