### PR TITLE
refs #38, fixes case where choices is empty but unlisted_choice is enabled

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -241,5 +241,5 @@ c.KubeSpawner.profile_list = [
             },
         },
         "slug": "custom",
-    }
+    },
 ]

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -223,4 +223,23 @@ c.KubeSpawner.profile_list = [
             },
         },
     },
+    {
+        "description": "Specify your own docker image (must have python and jupyterhub installed in it)",
+        "display_name": "Bring your own image",
+        "profile_options": {
+            "image": {
+                "choices": {},
+                "display_name": "Image",
+                "unlisted_choice": {
+                    "display_name": "Custom image",
+                    "enabled": True,
+                    "kubespawner_override": {"image": "{value}"},
+                    "validation_message": "Must be a publicly available docker image, of form <image-name>:<tag>",
+                    "validation_regex": "^.+:.+$",
+                    "display_name_in_choices": "Other...",
+                },
+            },
+        },
+        "slug": "custom",
+    }
 ]

--- a/setupTests.js
+++ b/setupTests.js
@@ -160,22 +160,24 @@ window.profileList = [
     },
   },
   {
-    "description": "Specify your own docker image (must have python and jupyterhub installed in it)",
-    "display_name": "Bring your own image",
-    "profile_options": {
-        "image": {
-            "choices": {},
-            "display_name": "Image",
-            "unlisted_choice": {
-                "display_name": "Custom image",
-                "enabled": true,
-                "kubespawner_override": {"image": "{value}"},
-                "validation_message": "Must be a publicly available docker image, of form <image-name>:<tag>",
-                "validation_regex": "^.+:.+$",
-                "display_name_in_choices": "Other...",
-            },
+    description:
+      "Specify your own docker image (must have python and jupyterhub installed in it)",
+    display_name: "Bring your own image",
+    profile_options: {
+      image: {
+        choices: {},
+        display_name: "Image",
+        unlisted_choice: {
+          display_name: "Custom image",
+          enabled: true,
+          kubespawner_override: { image: "{value}" },
+          validation_message:
+            "Must be a publicly available docker image, of form <image-name>:<tag>",
+          validation_regex: "^.+:.+$",
+          display_name_in_choices: "Other...",
         },
+      },
     },
-    "slug": "custom",
-  }  
+    slug: "custom",
+  },
 ];

--- a/setupTests.js
+++ b/setupTests.js
@@ -159,4 +159,23 @@ window.profileList = [
       },
     },
   },
+  {
+    "description": "Specify your own docker image (must have python and jupyterhub installed in it)",
+    "display_name": "Bring your own image",
+    "profile_options": {
+        "image": {
+            "choices": {},
+            "display_name": "Image",
+            "unlisted_choice": {
+                "display_name": "Custom image",
+                "enabled": true,
+                "kubespawner_override": {"image": "{value}"},
+                "validation_message": "Must be a publicly available docker image, of form <image-name>:<tag>",
+                "validation_regex": "^.+:.+$",
+                "display_name_in_choices": "Other...",
+            },
+        },
+    },
+    "slug": "custom",
+  }  
 ];

--- a/setupTests.js
+++ b/setupTests.js
@@ -166,9 +166,9 @@ window.profileList = [
     profile_options: {
       image: {
         choices: {},
-        display_name: "Image",
+        display_name: "Image - No options",
         unlisted_choice: {
-          display_name: "Custom image",
+          display_name: "Docker image",
           enabled: true,
           kubespawner_override: { image: "{value}" },
           validation_message:

--- a/src/ProfileForm.test.js
+++ b/src/ProfileForm.test.js
@@ -155,7 +155,7 @@ test("Multiple profiles renders", async () => {
   expect(screen.getByLabelText("Resource Allocation").tabIndex).toEqual(-1);
 });
 
-test('select with no options should not render', () => {
+test("select with no options should not render", () => {
   render(
     <SpawnerFormProvider>
       <ProfileForm />

--- a/src/ProfileForm.test.js
+++ b/src/ProfileForm.test.js
@@ -154,3 +154,12 @@ test("Multiple profiles renders", async () => {
   expect(smallImageField.tabIndex).toEqual(-1);
   expect(screen.getByLabelText("Resource Allocation").tabIndex).toEqual(-1);
 });
+
+test('select with no options should not render', () => {
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  expect(screen.queryByLabelText("Image - No options")).not.toBeInTheDocument();
+});

--- a/src/ResourceSelect.jsx
+++ b/src/ResourceSelect.jsx
@@ -6,23 +6,25 @@ import { SelectField, TextField } from "./components/form/fields";
 function ResourceSelect({ id, profile, config, customOptions = [] }) {
   const { display_name, unlisted_choice } = config;
 
-  const { options, defaultOption } = useSelectOptions(config, customOptions);
+  const { options, defaultOption, hasDefaultChoices } = useSelectOptions(config, customOptions);
   const { profile: selectedProfile } = useContext(SpawnerFormContext);
   const FIELD_ID = `profile-option-${profile}--${id}`;
   const FIELD_ID_UNLISTED = `${FIELD_ID}--unlisted-choice`;
 
   const isActive = selectedProfile?.slug === profile;
-  const [value, setValue] = useState(defaultOption.value);
+  const [value, setValue] = useState(defaultOption?.value);
   const [unlistedChoiceValue, setUnlistedChoiceValue] = useState("");
 
   if (!options.length > 0) {
     return null;
   }
 
+
   const selectedCustomOption = customOptions.find((opt) => opt.value === value);
 
   return (
     <>
+      {hasDefaultChoices && (
       <SelectField
         id={FIELD_ID}
         label={display_name}
@@ -37,6 +39,7 @@ function ResourceSelect({ id, profile, config, customOptions = [] }) {
           }
         }
       />
+      )}
       {value === "unlisted_choice" && (
         <TextField
           id={FIELD_ID_UNLISTED}

--- a/src/ResourceSelect.jsx
+++ b/src/ResourceSelect.jsx
@@ -6,7 +6,10 @@ import { SelectField, TextField } from "./components/form/fields";
 function ResourceSelect({ id, profile, config, customOptions = [] }) {
   const { display_name, unlisted_choice } = config;
 
-  const { options, defaultOption, hasDefaultChoices } = useSelectOptions(config, customOptions);
+  const { options, defaultOption, hasDefaultChoices } = useSelectOptions(
+    config,
+    customOptions,
+  );
   const { profile: selectedProfile } = useContext(SpawnerFormContext);
   const FIELD_ID = `profile-option-${profile}--${id}`;
   const FIELD_ID_UNLISTED = `${FIELD_ID}--unlisted-choice`;
@@ -19,26 +22,25 @@ function ResourceSelect({ id, profile, config, customOptions = [] }) {
     return null;
   }
 
-
   const selectedCustomOption = customOptions.find((opt) => opt.value === value);
 
   return (
     <>
       {hasDefaultChoices && (
-      <SelectField
-        id={FIELD_ID}
-        label={display_name}
-        options={options}
-        defaultOption={defaultOption}
-        value={value}
-        onChange={(e) => setValue(e.value)}
-        tabIndex={isActive ? "0" : "-1"}
-        validate={
-          isActive && {
-            required: "Select a value.",
+        <SelectField
+          id={FIELD_ID}
+          label={display_name}
+          options={options}
+          defaultOption={defaultOption}
+          value={value}
+          onChange={(e) => setValue(e.value)}
+          tabIndex={isActive ? "0" : "-1"}
+          validate={
+            isActive && {
+              required: "Select a value.",
+            }
           }
-        }
-      />
+        />
       )}
       {value === "unlisted_choice" && (
         <TextField

--- a/src/hooks/useSelectOptions.js
+++ b/src/hooks/useSelectOptions.js
@@ -23,13 +23,15 @@ function useSelectOptions(config, customOptions = []) {
 
     return [...defaultChoices, ...extraChoices, ...customOptions];
   }, [choices]);
-  
+
   // The default choice is either the choice marked as default,
   // OR the first explicit choice
   // OR the first item from options which could be an extra or custom choice
   const defaultChoiceName =
     Object.keys(choices).find((choiceName) => choices[choiceName].default) ||
-    Object.keys(choices).length > 0 ? Object.keys(choices)[0] : options[0].value;
+    Object.keys(choices).length > 0
+      ? Object.keys(choices)[0]
+      : options[0].value;
 
   const defaultOption = options.find(
     (option) => option.value === defaultChoiceName,
@@ -38,7 +40,7 @@ function useSelectOptions(config, customOptions = []) {
   return {
     options,
     defaultOption,
-    hasDefaultChoices
+    hasDefaultChoices,
   };
 }
 

--- a/src/hooks/useSelectOptions.js
+++ b/src/hooks/useSelectOptions.js
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 function useSelectOptions(config, customOptions = []) {
   const { choices, unlisted_choice } = config;
-
+  const hasDefaultChoices = Object.keys(choices).length > 0;
   const options = useMemo(() => {
     const defaultChoices = Object.keys(choices).map((choiceName) => {
       return {
@@ -23,10 +23,13 @@ function useSelectOptions(config, customOptions = []) {
 
     return [...defaultChoices, ...extraChoices, ...customOptions];
   }, [choices]);
-
+  
+  // The default choice is either the choice marked as default,
+  // OR the first explicit choice
+  // OR the first item from options which could be an extra or custom choice
   const defaultChoiceName =
     Object.keys(choices).find((choiceName) => choices[choiceName].default) ||
-    Object.keys(choices)[0];
+    Object.keys(choices).length > 0 ? Object.keys(choices)[0] : options[0].value;
 
   const defaultOption = options.find(
     (option) => option.value === defaultChoiceName,
@@ -35,6 +38,7 @@ function useSelectOptions(config, customOptions = []) {
   return {
     options,
     defaultOption,
+    hasDefaultChoices
   };
 }
 


### PR DESCRIPTION
@oliverroick this got a bit hairy, but I think this was the simplest possible change I could think of to fix the issue and ensure the default handling is correct.

I added a profile list item to the test config, but am seeing some existing tests are failing with duplicate items on the page - which makes sense, but it might be good to get some help from you to fix @oliverroick 

@oliverroick maybe easiest to have a quick chat to walk through the fixes and you can maybe make suggestions for doing this better.
