### PR TITLE
try onClick on whole profile to select

### DIFF
--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -58,7 +58,7 @@ function Form() {
         const { display_name, description, profile_options, slug } = profile;
 
         return (
-          <div key={slug} className="profile-select">
+          <div key={slug} className={`profile-select ${selectedProfile?.slug === slug ? 'bg-success' : ''}`}>
             <input
               type="radio"
               name="select-profile"

--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -68,7 +68,12 @@ function Form() {
               required
               checked={selectedProfile?.slug === slug}
             />
-            <div className="profile-select-body" onClick={()=> { setProfile(slug)}}>
+            <div
+              className="profile-select-body"
+              onClick={() => {
+                setProfile(slug);
+              }}
+            >
               <label
                 htmlFor={`profile-option-${slug}`}
                 className="profile-select-label"

--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -68,7 +68,7 @@ function Form() {
               required
               checked={selectedProfile?.slug === slug}
             />
-            <div className="profile-select-body">
+            <div className="profile-select-body" onClick={()=> { setProfile(slug)}}>
               <label
                 htmlFor={`profile-option-${slug}`}
                 className="profile-select-label"

--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -58,7 +58,10 @@ function Form() {
         const { display_name, description, profile_options, slug } = profile;
 
         return (
-          <div key={slug} className={`profile-select ${selectedProfile?.slug === slug ? 'bg-success' : ''}`}>
+          <div
+            key={slug}
+            className={`profile-select ${selectedProfile?.slug === slug ? "bg-success" : ""}`}
+          >
             <input
               type="radio"
               name="select-profile"

--- a/src/ProfileForm.test.js
+++ b/src/ProfileForm.test.js
@@ -136,7 +136,8 @@ test("Multiple profiles renders", async () => {
   const radio = screen.getByRole("radio", { name: "GPU Nvidia Tesla T4 GPU" });
   await user.click(radio);
 
-  expect(screen.getByLabelText("Image - GPU").tabIndex).toEqual(0);
+  const imageField = screen.getByLabelText("Image - GPU");
+  expect(imageField.tabIndex).toEqual(0);
   expect(screen.getByLabelText("Resource Allocation - GPU").tabIndex).toEqual(
     0,
   );
@@ -149,10 +150,14 @@ test("Multiple profiles renders", async () => {
   await user.click(customImageField);
   await user.click(document.body);
 
-  expect(screen.queryByText("Enter a value.")).not.toBeInTheDocument();
+  expect(screen.queryByText("Enter a value.")).toBeInTheDocument();
 
-  expect(smallImageField.tabIndex).toEqual(-1);
-  expect(screen.getByLabelText("Resource Allocation").tabIndex).toEqual(-1);
+  expect(smallImageField.tabIndex).toEqual(0);
+  expect(screen.getByLabelText("Resource Allocation").tabIndex).toEqual(0);
+  expect(imageField.tabIndex).toEqual(-1);
+  expect(screen.getByLabelText("Resource Allocation - GPU").tabIndex).toEqual(
+    -1,
+  );
 });
 
 test("select with no options should not render", () => {
@@ -181,22 +186,3 @@ test("profile marked as default is selected by default", () => {
   });
   expect(nonDefaultRadio.checked).toBeFalsy();
 });
-
-// test("clicking on a profile option div selects it", async () => {
-//   const user = userEvent.setup();
-//   const { container } = render(
-//     <SpawnerFormProvider>
-//       <ProfileForm />
-//     </SpawnerFormProvider>,
-//   );
-//   const profileElements = container.querySelectorAll('.profile-select');
-//   console.log('profiles', profileElements.length);
-//   const firstProfile = profileElements[0];
-//   const lastProfile = profileElements[profileElements.length - 1];
-//   await user.click(firstProfile);
-//   console.log('first profile', firstProfile.classList);
-//   expect(firstProfile.classList.contains('bg-success')).toBeTruthy();
-//   expect(lastProfile.classList.contains('bg-success')).toBeFalsy();
-//   const hiddenRadio = container.querySelector('[name="profile"]');
-//   expect(hiddenRadio.value).toEqual("foobar");
-// });

--- a/src/ProfileForm.test.js
+++ b/src/ProfileForm.test.js
@@ -181,3 +181,22 @@ test("profile marked as default is selected by default", () => {
   });
   expect(nonDefaultRadio.checked).toBeFalsy();
 });
+
+// test("clicking on a profile option div selects it", async () => {
+//   const user = userEvent.setup();
+//   const { container } = render(
+//     <SpawnerFormProvider>
+//       <ProfileForm />
+//     </SpawnerFormProvider>,
+//   );
+//   const profileElements = container.querySelectorAll('.profile-select');
+//   console.log('profiles', profileElements.length);
+//   const firstProfile = profileElements[0];
+//   const lastProfile = profileElements[profileElements.length - 1];
+//   await user.click(firstProfile);
+//   console.log('first profile', firstProfile.classList);
+//   expect(firstProfile.classList.contains('bg-success')).toBeTruthy();
+//   expect(lastProfile.classList.contains('bg-success')).toBeFalsy();
+//   const hiddenRadio = container.querySelector('[name="profile"]');
+//   expect(hiddenRadio.value).toEqual("foobar");
+// });

--- a/src/form.css
+++ b/src/form.css
@@ -6,9 +6,8 @@
 /* Layout */
 
 .profile-select {
-  margin-bottom: 5rem;
   display: flex;
-  padding: 2rem;
+  padding: 5rem 2rem;
   flex-direction: row;
   border-bottom: 1px solid #ccc;
 }

--- a/src/form.css
+++ b/src/form.css
@@ -8,6 +8,7 @@
 .profile-select {
   margin-bottom: 5rem;
   display: flex;
+  padding: 2rem;
   flex-direction: row;
   border-bottom: 1px solid #ccc;
 }


### PR DESCRIPTION
Fixes #40 -

This feels a bit awful @oliverroick @yuvipanda 

This does (I think) replicate what the current kubespawner frontend does, where if the user clicks anywhere on a profile option, it selects the radio for that option.

I do think we should re-think these radio inputs for selection, and perhaps something like a more accordion-ish interface might make this a bit more obvious to the user.

I'm a bit worried that this makes it quite easy for a user to accidentally select a profile option when they didn't mean to, etc.

@yuvipanda if you get the time, could you test this and see if this is the behaviour you were hoping for?

For reference, this was the issue on `kubespawner` when we first implemented "unlisted_choice" about essentially the same thing: https://github.com/jupyterhub/kubespawner/issues/696 

If it seems better, I can try trying the profile change to changing value in the `<select>` input. Honestly, I don't have a strong opinion on how this should work - just that I don't love the approach in this PR.