### PR TITLE
Hide profile select for single-profile configs

### DIFF
--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -59,25 +59,28 @@ function Form() {
 
         return (
           <div key={slug} className="profile-select">
-            <input
-              type="radio"
-              name="select-profile"
-              id={`profile-option-${slug}`}
-              value={slug}
-              onChange={handleProfileSelect}
-              required
-              checked={selectedProfile?.slug === slug}
-            />
+            {profileList.length > 1 && (
+              <input
+                type="radio"
+                name="select-profile"
+                id={`profile-option-${slug}`}
+                aria-labelledby={`profile-option-${slug}-label`}
+                value={slug}
+                onChange={handleProfileSelect}
+                required
+                checked={selectedProfile?.slug === slug}
+              />
+            )}
             <div className="profile-select-body">
-              <label
-                htmlFor={`profile-option-${slug}`}
+              <div
+                id={`profile-option-${slug}-label`}
                 className="profile-select-label"
               >
                 <span className="profile-select-label-heading">
                   {display_name}
                 </span>
                 <span>{description}</span>
-              </label>
+              </div>
 
               <ProfileOptions profile={slug} config={profile_options} />
             </div>

--- a/src/form.css
+++ b/src/form.css
@@ -10,13 +10,10 @@
   display: flex;
   flex-direction: row;
   border-bottom: 1px solid #ccc;
+  gap: 3rem;
 }
 
-.profile-select-body {
-  margin-left: 3rem;
-}
-
-.profile-select-body label {
+.profile-select-body .profile-select-label {
   font-weight: normal;
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
Implements #49 

- Hides the profile-select radio if only one profile is available
- Changed the `label` to a `div` so the semantics don't break when there is no radio-input. Wired the input and label via `aria-labelledby`
- Fix the CSS for the profile select flex box to use `gap` instead of `margin-left`, so there is no margin when there is no input