### PR TITLE
fix: Add name prop to TextField

### DIFF
--- a/src/components/form/fields.jsx
+++ b/src/components/form/fields.jsx
@@ -88,6 +88,7 @@ export function TextField({
       <input
         type="text"
         id={id}
+        name={id}
         value={value}
         pattern={pattern}
         onChange={onChange}


### PR DESCRIPTION
Fixes #59

Adds the `name` attribute to `TextField` so the fields are included in form submission. 