### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,15 @@ repos:
           - eslint@8.56.0
           - eslint-plugin-react
 
+  # Lint: Find known typos
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
+    rev: v2.2.6
+    hooks:
+    - id: codespell
+      additional_dependencies:
+      - tomli
+
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration
 ci:
   autoupdate_schedule: monthly

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The primary contents are:
    `HTML` for constructing the form itself. This can contain multiple templates
    that are composed together using all of jinja2's composition features (like `include`)
 2. `src/` contains JS and CSS that are packaged via standard frontend bundling
-   tools (`webpack` and `babel`), outputing assets into `jupyterhub_fancy_profiles/static/`.
+   tools (`webpack` and `babel`), outputting assets into `jupyterhub_fancy_profiles/static/`.
    This allows us to use _standard_ frontend tooling to write JS & CSS - for
    example, [xterm.js](http://xtermjs.org/) can be used without many complications.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,10 @@ version_file = "jupyterhub_fancy_profiles/_version.py"
 [tool.setuptools.packages.find]
 where = [""]
 include = ["jupyterhub_fancy_profiles*"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,package-lock.json,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -110,7 +110,7 @@ export function ImageBuilder({ name }) {
     });
   };
 
-  // We render everything, but only toggle visibility based on wether we are being
+  // We render everything, but only toggle visibility based on whether we are being
   // shown or hidden. This provides for more DOM stability, and also allows the image
   // to continue being built evn if the user moves away elsewhere. When hidden, we just
   // don't generate the hidden input that posts the built image out.


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.