### PR TITLE
Add repo validation, enable branch selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterhub/binderhub-client": "0.4.0",
+        "configurable-http-proxy": "^4.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-select": "^5.7.4",
@@ -1866,6 +1867,26 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "http://verdaccio.ds.io:4873/@colors%2fcolors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "http://verdaccio.ds.io:4873/@dabh%2fdiagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -3638,6 +3659,12 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "http://verdaccio.ds.io:4873/@types%2ftriple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
@@ -4239,6 +4266,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "http://verdaccio.ds.io:4873/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4541,6 +4574,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "http://verdaccio.ds.io:4873/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -4866,6 +4905,16 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "http://verdaccio.ds.io:4873/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -4879,11 +4928,31 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "http://verdaccio.ds.io:4873/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "http://verdaccio.ds.io:4873/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4901,7 +4970,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4968,6 +5036,25 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/configurable-http-proxy": {
+      "version": "4.6.2",
+      "resolved": "http://verdaccio.ds.io:4873/configurable-http-proxy/-/configurable-http-proxy-4.6.2.tgz",
+      "integrity": "sha512-29kzKOyBlUmxBRq/ecKgsH712yLWUaBGESD3iq4UVKBL8NjyXGt+B3mv8xuq9gDn7PYVnotSbDMj5gScUJOF+w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "commander": "~7.2",
+        "http-proxy-node16": "1.0.3",
+        "prom-client": "14.2.0",
+        "strftime": "~0.10.0",
+        "winston": "~3.13.0"
+      },
+      "bin": {
+        "configurable-http-proxy": "bin/configurable-http-proxy"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
@@ -5607,6 +5694,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -6275,8 +6368,7 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6455,6 +6547,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "http://verdaccio.ds.io:4873/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -6579,11 +6677,16 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "http://verdaccio.ds.io:4873/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7123,6 +7226,20 @@
         }
       }
     },
+    "node_modules/http-proxy-node16": {
+      "version": "1.0.3",
+      "resolved": "http://verdaccio.ds.io:4873/http-proxy-node16/-/http-proxy-node16-1.0.3.tgz",
+      "integrity": "sha512-GReWWNIbJUCqYP7vcaaOGX0T+o8BpSP2VTZ4nCebJ9nbl3seUr5gCnLNpc4R2D0BK6kSY2hTsdpEV3QH2TobDg==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -7255,8 +7372,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -7634,7 +7750,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -9803,6 +9918,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/launch-editor": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
@@ -9895,6 +10016,23 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/logform": {
+      "version": "2.6.1",
+      "resolved": "http://verdaccio.ds.io:4873/logform/-/logform-2.6.1.tgz",
+      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -10081,8 +10219,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -10374,6 +10511,15 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -10852,6 +10998,18 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/prom-client": {
+      "version": "14.2.0",
+      "resolved": "http://verdaccio.ds.io:4873/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/promise-polyfill": {
       "version": "8.3.0",
       "resolved": "http://verdaccio.ds.io:4873/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
@@ -11118,7 +11276,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -11295,8 +11452,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -11431,7 +11587,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11462,6 +11617,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "http://verdaccio.ds.io:4873/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -11787,6 +11951,21 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "http://verdaccio.ds.io:4873/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "http://verdaccio.ds.io:4873/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11885,6 +12064,15 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "http://verdaccio.ds.io:4873/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -11915,11 +12103,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strftime": {
+      "version": "0.10.3",
+      "resolved": "http://verdaccio.ds.io:4873/strftime/-/strftime-0.10.3.tgz",
+      "integrity": "sha512-DZrDUeIF73eKJ4/GgGuv8UHWcUQPYDYfDeQFj3jrx+JZl6GQE656MbHIpvbo4mEG9a5DgS8GRCc5DxJXD2udDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -12154,6 +12350,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "http://verdaccio.ds.io:4873/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/terser": {
       "version": "5.30.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.2.tgz",
@@ -12244,6 +12449,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -12316,6 +12527,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "http://verdaccio.ds.io:4873/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -12587,8 +12807,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -13196,6 +13415,42 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
+    },
+    "node_modules/winston": {
+      "version": "3.13.1",
+      "resolved": "http://verdaccio.ds.io:4873/winston/-/winston-3.13.1.tgz",
+      "integrity": "sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.6.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.7.1",
+      "resolved": "http://verdaccio.ds.io:4873/winston-transport/-/winston-transport-4.7.1.tgz",
+      "integrity": "sha512-wQCXXVgfv/wUPOfb2x0ruxzwkcZfxcktz6JIMUaPLmcNhO4bZTwA/WtDWK74xV3F2dKu8YadrFv0qhwYjVEwhA==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.6.1",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -14633,6 +14888,21 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "http://verdaccio.ds.io:4873/@colors%2fcolors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
+    },
+    "@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "http://verdaccio.ds.io:4873/@dabh%2fdiagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -16057,6 +16327,11 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "http://verdaccio.ds.io:4873/@types%2ftriple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
     "@types/ws": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
@@ -16548,6 +16823,11 @@
         "is-shared-array-buffer": "^1.0.2"
       }
     },
+    "async": {
+      "version": "3.2.6",
+      "resolved": "http://verdaccio.ds.io:4873/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -16774,6 +17054,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true
+    },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "http://verdaccio.ds.io:4873/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "body-parser": {
       "version": "1.20.2",
@@ -17005,6 +17290,15 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
+    "color": {
+      "version": "3.2.1",
+      "resolved": "http://verdaccio.ds.io:4873/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "requires": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -17018,11 +17312,29 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "http://verdaccio.ds.io:4873/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.4",
+      "resolved": "http://verdaccio.ds.io:4873/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "requires": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -17036,8 +17348,7 @@
     "commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -17097,6 +17408,18 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "configurable-http-proxy": {
+      "version": "4.6.2",
+      "resolved": "http://verdaccio.ds.io:4873/configurable-http-proxy/-/configurable-http-proxy-4.6.2.tgz",
+      "integrity": "sha512-29kzKOyBlUmxBRq/ecKgsH712yLWUaBGESD3iq4UVKBL8NjyXGt+B3mv8xuq9gDn7PYVnotSbDMj5gScUJOF+w==",
+      "requires": {
+        "commander": "~7.2",
+        "http-proxy-node16": "1.0.3",
+        "prom-client": "14.2.0",
+        "strftime": "~0.10.0",
+        "winston": "~3.13.0"
+      }
     },
     "connect-history-api-fallback": {
       "version": "2.0.0",
@@ -17560,6 +17883,11 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -18039,8 +18367,7 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.3.0",
@@ -18197,6 +18524,11 @@
         "bser": "2.1.1"
       }
     },
+    "fecha": {
+      "version": "4.2.3",
+      "resolved": "http://verdaccio.ds.io:4873/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -18296,11 +18628,15 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "http://verdaccio.ds.io:4873/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
     "follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "dev": true
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -18689,6 +19025,16 @@
         "micromatch": "^4.0.2"
       }
     },
+    "http-proxy-node16": {
+      "version": "1.0.3",
+      "resolved": "http://verdaccio.ds.io:4873/http-proxy-node16/-/http-proxy-node16-1.0.3.tgz",
+      "integrity": "sha512-GReWWNIbJUCqYP7vcaaOGX0T+o8BpSP2VTZ4nCebJ9nbl3seUr5gCnLNpc4R2D0BK6kSY2hTsdpEV3QH2TobDg==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
     "https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -18780,8 +19126,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.7",
@@ -19023,8 +19368,7 @@
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-string": {
       "version": "1.0.7",
@@ -20630,6 +20974,11 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "launch-editor": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
@@ -20704,6 +21053,19 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "logform": {
+      "version": "2.6.1",
+      "resolved": "http://verdaccio.ds.io:4873/logform/-/logform-2.6.1.tgz",
+      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+      "requires": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -20845,8 +21207,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -21056,6 +21417,14 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -21381,6 +21750,14 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "prom-client": {
+      "version": "14.2.0",
+      "resolved": "http://verdaccio.ds.io:4873/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-polyfill": {
       "version": "8.3.0",
       "resolved": "http://verdaccio.ds.io:4873/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
@@ -21581,7 +21958,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -21718,8 +22094,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
       "version": "1.22.8",
@@ -21804,8 +22179,7 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex-test": {
       "version": "1.0.3",
@@ -21817,6 +22191,11 @@
         "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "http://verdaccio.ds.io:4873/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -22089,6 +22468,21 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "http://verdaccio.ds.io:4873/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "http://verdaccio.ds.io:4873/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -22174,6 +22568,11 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "http://verdaccio.ds.io:4873/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -22197,11 +22596,15 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
+    "strftime": {
+      "version": "0.10.3",
+      "resolved": "http://verdaccio.ds.io:4873/strftime/-/strftime-0.10.3.tgz",
+      "integrity": "sha512-DZrDUeIF73eKJ4/GgGuv8UHWcUQPYDYfDeQFj3jrx+JZl6GQE656MbHIpvbo4mEG9a5DgS8GRCc5DxJXD2udDQ=="
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -22364,6 +22767,14 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true
     },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "http://verdaccio.ds.io:4873/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
+      }
+    },
     "terser": {
       "version": "5.30.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.2.tgz",
@@ -22420,6 +22831,11 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
+    },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -22479,6 +22895,11 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "triple-beam": {
+      "version": "1.4.1",
+      "resolved": "http://verdaccio.ds.io:4873/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="
     },
     "tslib": {
       "version": "2.6.2",
@@ -22665,8 +23086,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -23096,6 +23516,34 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
+    },
+    "winston": {
+      "version": "3.13.1",
+      "resolved": "http://verdaccio.ds.io:4873/winston/-/winston-3.13.1.tgz",
+      "integrity": "sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==",
+      "requires": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.6.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.7.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.7.1",
+      "resolved": "http://verdaccio.ds.io:4873/winston-transport/-/winston-transport-4.7.1.tgz",
+      "integrity": "sha512-wQCXXVgfv/wUPOfb2x0ruxzwkcZfxcktz6JIMUaPLmcNhO4bZTwA/WtDWK74xV3F2dKu8YadrFv0qhwYjVEwhA==",
+      "requires": {
+        "logform": "^2.6.1",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterhub/binderhub-client": "0.4.0",
-        "configurable-http-proxy": "^4.6.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-select": "^5.7.4",
@@ -34,6 +33,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-fetch-mock": "^3.0.3",
         "react-test-renderer": "^18.3.1",
         "style-loader": "^3.3.2",
         "webpack": "^5.6.0",
@@ -1866,24 +1866,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-      "dependencies": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
-      }
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -3656,11 +3638,6 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
-    "node_modules/@types/triple-beam": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
     "node_modules/@types/ws": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
@@ -4262,11 +4239,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4569,11 +4541,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/bintrees": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
-      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -4899,15 +4866,6 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -4921,29 +4879,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
-    },
-    "node_modules/colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "dependencies": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4961,6 +4901,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5027,24 +4968,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "node_modules/configurable-http-proxy": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/configurable-http-proxy/-/configurable-http-proxy-4.6.1.tgz",
-      "integrity": "sha512-l6AFE1Jiqlxiv+kIcwG3hrka3NDRorvsCyH9l6u8L7L30pzSO5Dhgq43RoS6vkXo7bolrdUIJWKw6tB8loDaFA==",
-      "dependencies": {
-        "commander": "~7.2",
-        "http-proxy": "^1.18.1",
-        "prom-client": "14.2.0",
-        "strftime": "~0.10.0",
-        "winston": "~3.11.0"
-      },
-      "bin": {
-        "configurable-http-proxy": "bin/configurable-http-proxy"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
@@ -5220,6 +5143,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "http://verdaccio.ds.io:4873/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -5674,11 +5607,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -6347,7 +6275,8 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6526,11 +6455,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -6655,15 +6579,11 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-    },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7155,6 +7075,7 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -7334,7 +7255,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -7712,6 +7634,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -8611,6 +8534,17 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "http://verdaccio.ds.io:4873/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
       }
     },
     "node_modules/jest-get-type": {
@@ -9869,11 +9803,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-    },
     "node_modules/launch-editor": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
@@ -9966,22 +9895,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/logform": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
-      "dependencies": {
-        "@colors/colors": "1.6.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -10168,7 +10081,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -10221,6 +10135,52 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "http://verdaccio.ds.io:4873/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "http://verdaccio.ds.io:4873/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "http://verdaccio.ds.io:4873/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "http://verdaccio.ds.io:4873/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -10414,14 +10374,6 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "dependencies": {
-        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -10900,16 +10852,12 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "node_modules/prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
-      "dependencies": {
-        "tdigest": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "http://verdaccio.ds.io:4873/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -11170,6 +11118,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -11346,7 +11295,8 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -11481,6 +11431,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11511,14 +11462,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -11844,19 +11787,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11955,14 +11885,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -11993,18 +11915,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/strftime": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.2.tgz",
-      "integrity": "sha512-Y6IZaTVM80chcMe7j65Gl/0nmlNdtt+KWPle5YeCAjmsBfw+id2qdaJ5MDrxUq+OmHKab+jHe7mUjU/aNMSZZg==",
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -12239,14 +12154,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tdigest": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
-      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
-      "dependencies": {
-        "bintrees": "1.0.2"
-      }
-    },
     "node_modules/terser": {
       "version": "5.30.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.2.tgz",
@@ -12337,11 +12244,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -12414,14 +12316,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/triple-beam": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -12693,7 +12587,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -13301,40 +13196,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
-    },
-    "node_modules/winston": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
-      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
-      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
-      "dependencies": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.6.0",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -14772,21 +14633,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
-    },
-    "@dabh/diagnostics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-      "requires": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
-      }
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -16211,11 +16057,6 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
-    "@types/triple-beam": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
     "@types/ws": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
@@ -16707,11 +16548,6 @@
         "is-shared-array-buffer": "^1.0.2"
       }
     },
-    "async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -16938,11 +16774,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true
-    },
-    "bintrees": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
-      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "body-parser": {
       "version": "1.20.2",
@@ -17174,15 +17005,6 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
-    "color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "requires": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -17196,29 +17018,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
-    "color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
-    },
-    "colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "requires": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -17232,7 +17036,8 @@
     "commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -17292,18 +17097,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "configurable-http-proxy": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/configurable-http-proxy/-/configurable-http-proxy-4.6.1.tgz",
-      "integrity": "sha512-l6AFE1Jiqlxiv+kIcwG3hrka3NDRorvsCyH9l6u8L7L30pzSO5Dhgq43RoS6vkXo7bolrdUIJWKw6tB8loDaFA==",
-      "requires": {
-        "commander": "~7.2",
-        "http-proxy": "^1.18.1",
-        "prom-client": "14.2.0",
-        "strftime": "~0.10.0",
-        "winston": "~3.11.0"
-      }
     },
     "connect-history-api-fallback": {
       "version": "2.0.0",
@@ -17435,6 +17228,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "http://verdaccio.ds.io:4873/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.12"
       }
     },
     "cross-spawn": {
@@ -17758,11 +17560,6 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
-    },
-    "enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -18242,7 +18039,8 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "events": {
       "version": "3.3.0",
@@ -18399,11 +18197,6 @@
         "bser": "2.1.1"
       }
     },
-    "fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
-    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -18503,15 +18296,11 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
-    "fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-    },
     "follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -18869,6 +18658,7 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -18990,7 +18780,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "internal-slot": {
       "version": "1.0.7",
@@ -19232,7 +19023,8 @@
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.7",
@@ -19878,6 +19670,16 @@
         "@types/node": "*",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
+      }
+    },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "http://verdaccio.ds.io:4873/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
       }
     },
     "jest-get-type": {
@@ -20828,11 +20630,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-    },
     "launch-editor": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
@@ -20907,19 +20704,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "logform": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
-      "requires": {
-        "@colors/colors": "1.6.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -21061,7 +20845,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -21096,6 +20881,39 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "http://verdaccio.ds.io:4873/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "http://verdaccio.ds.io:4873/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "http://verdaccio.ds.io:4873/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "http://verdaccio.ds.io:4873/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "1.3.1",
@@ -21238,14 +21056,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "requires": {
-        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -21571,13 +21381,11 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
-      "requires": {
-        "tdigest": "^0.1.1"
-      }
+    "promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "http://verdaccio.ds.io:4873/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true
     },
     "prompts": {
       "version": "2.4.2",
@@ -21773,6 +21581,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -21909,7 +21718,8 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "resolve": {
       "version": "1.22.8",
@@ -21994,7 +21804,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-regex-test": {
       "version": "1.0.3",
@@ -22006,11 +21817,6 @@
         "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
       }
-    },
-    "safe-stable-stringify": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -22283,21 +22089,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-        }
-      }
-    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -22383,11 +22174,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
-    },
     "stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -22411,15 +22197,11 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
-    "strftime": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.2.tgz",
-      "integrity": "sha512-Y6IZaTVM80chcMe7j65Gl/0nmlNdtt+KWPle5YeCAjmsBfw+id2qdaJ5MDrxUq+OmHKab+jHe7mUjU/aNMSZZg=="
-    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -22582,14 +22364,6 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true
     },
-    "tdigest": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
-      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
-      "requires": {
-        "bintrees": "1.0.2"
-      }
-    },
     "terser": {
       "version": "5.30.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.2.tgz",
@@ -22646,11 +22420,6 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
-    },
-    "text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -22710,11 +22479,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "triple-beam": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="
     },
     "tslib": {
       "version": "2.6.2",
@@ -22901,7 +22665,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -23331,34 +23096,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
-    },
-    "winston": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
-      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
-      "requires": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
-      }
-    },
-    "winston-transport": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
-      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
-      "requires": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.6.0",
-        "triple-beam": "^1.3.0"
-      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@jupyterhub/binderhub-client": "0.4.0",
-    "configurable-http-proxy": "^4.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-select": "^5.7.4",
@@ -48,6 +47,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3",
     "react-test-renderer": "^18.3.1",
     "style-loader": "^3.3.2",
     "webpack": "^5.6.0",
@@ -55,6 +55,7 @@
     "webpack-dev-server": "^4.9.3"
   },
   "jest": {
+    "automock": false,
     "testEnvironment": "jsdom",
     "testMatch": [
       "<rootDir>/src/**/*.test.js"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jupyterhub/binderhub-client": "0.4.0",
+    "configurable-http-proxy": "^4.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-select": "^5.7.4",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,4 +1,22 @@
+import {jest} from '@jest/globals';
 import "@testing-library/jest-dom";
+import fetchMock from "jest-fetch-mock";
+fetchMock.enableMocks();
+
+HTMLCanvasElement.prototype.getContext = () => {};
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
 
 window.profileList = [
   {

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,12 +1,12 @@
-import {jest} from '@jest/globals';
+import { jest } from "@jest/globals";
 import "@testing-library/jest-dom";
 import fetchMock from "jest-fetch-mock";
 fetchMock.enableMocks();
 
 HTMLCanvasElement.prototype.getContext = () => {};
-Object.defineProperty(window, 'matchMedia', {
+Object.defineProperty(window, "matchMedia", {
   writable: true,
-  value: jest.fn().mockImplementation(query => ({
+  value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
     onchange: null,

--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -114,7 +114,7 @@ export function ImageBuilder({ name }) {
       return;
     }
 
-    await buildImage(repo, ref, term, fitAddon, (imageName) => {
+    await buildImage(repoId, ref, term, fitAddon, (imageName) => {
       setCustomImage(imageName);
       term.write(
         "\nImage has been built! Click the start button to launch your server",

--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -160,11 +160,11 @@ export function ImageBuilder({ name }) {
           className={`profile-option-container ${repoError ? "has-error" : ""}`}
         >
           <div className="profile-option-label-container">
-            <label>Branch</label>
+            <label>Git Ref</label>
           </div>
           <div className="profile-option-control-container">
             <Select
-              aria-label="Branch"
+              aria-label="Git Ref"
               ref={branchFieldRef}
               {...refFieldProps}
               aria-invalid={!!refError}

--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -91,7 +91,8 @@ function ImageLogs({ setTerm, setFitAddon }) {
 }
 
 export function ImageBuilder({ name }) {
-  const { repo, repoId, repoFieldProps, repoError, repoIsValidating} = useRepositoryField();
+  const { repo, repoId, repoFieldProps, repoError, repoIsValidating } =
+    useRepositoryField();
   const { ref, refError, refFieldProps, refIsLoading } = useRefField(repoId);
   const repoFieldRef = useRef();
   const branchFieldRef = useRef();
@@ -150,7 +151,9 @@ export function ImageBuilder({ name }) {
             aria-invalid={!!repoError}
           />
           {repoIsValidating && (
-            <div className="profile-option-control-info">Validating repository...</div>
+            <div className="profile-option-control-info">
+              Validating repository...
+            </div>
           )}
           {repoError && (
             <div className="profile-option-control-error">{repoError}</div>
@@ -173,7 +176,9 @@ export function ImageBuilder({ name }) {
             isDisabled={!refFieldProps.options}
           />
           {refIsLoading && !refIsLoading && (
-            <div className="profile-option-control-info">Loading Git ref options...</div>
+            <div className="profile-option-control-info">
+              Loading Git ref options...
+            </div>
           )}
           {refError && (
             <div className="profile-option-control-error">{refError}</div>

--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -132,12 +132,12 @@ export function ImageBuilder({ name }) {
         <div className="profile-option-label-container">
           <b>Provider</b>
         </div>
-        <div className="profile-option-control-container">
-          GitHub
-        </div>
+        <div className="profile-option-control-container">GitHub</div>
       </div>
 
-      <div className={`profile-option-container ${repoError ? "has-error" : ""}`}>
+      <div
+        className={`profile-option-container ${repoError ? "has-error" : ""}`}
+      >
         <div className="profile-option-label-container">
           <label htmlFor="repo">Repository</label>
         </div>
@@ -149,18 +149,29 @@ export function ImageBuilder({ name }) {
             {...repoFieldProps}
             aria-invalid={!!repoError}
           />
-          {repoError && <div className="profile-option-control-error">{repoError}</div>}
+          {repoError && (
+            <div className="profile-option-control-error">{repoError}</div>
+          )}
         </div>
       </div>
 
       {refFieldProps.options && (
-        <div className={`profile-option-container ${repoError ? "has-error" : ""}`}>
+        <div
+          className={`profile-option-container ${repoError ? "has-error" : ""}`}
+        >
           <div className="profile-option-label-container">
             <label>Branch</label>
           </div>
           <div className="profile-option-control-container">
-            <Select aria-label="Branch" ref={branchFieldRef} {...refFieldProps} aria-invalid={!!refError} />
-            {refError && <div className="profile-option-control-error">{refError}</div>}
+            <Select
+              aria-label="Branch"
+              ref={branchFieldRef}
+              {...refFieldProps}
+              aria-invalid={!!refError}
+            />
+            {refError && (
+              <div className="profile-option-control-error">{refError}</div>
+            )}
           </div>
         </div>
       )}

--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -91,8 +91,8 @@ function ImageLogs({ setTerm, setFitAddon }) {
 }
 
 export function ImageBuilder({ name }) {
-  const { repo, repoId, repoFieldProps, repoError } = useRepositoryField();
-  const { ref, refError, refFieldProps } = useRefField(repoId);
+  const { repo, repoId, repoFieldProps, repoError, repoIsValidating} = useRepositoryField();
+  const { ref, refError, refFieldProps, refIsLoading } = useRefField(repoId);
   const repoFieldRef = useRef();
   const branchFieldRef = useRef();
 
@@ -149,32 +149,37 @@ export function ImageBuilder({ name }) {
             {...repoFieldProps}
             aria-invalid={!!repoError}
           />
+          {repoIsValidating && (
+            <div className="profile-option-control-info">Validating repository...</div>
+          )}
           {repoError && (
             <div className="profile-option-control-error">{repoError}</div>
           )}
         </div>
       </div>
 
-      {refFieldProps.options && (
-        <div
-          className={`profile-option-container ${repoError ? "has-error" : ""}`}
-        >
-          <div className="profile-option-label-container">
-            <label>Git Ref</label>
-          </div>
-          <div className="profile-option-control-container">
-            <Select
-              aria-label="Git Ref"
-              ref={branchFieldRef}
-              {...refFieldProps}
-              aria-invalid={!!refError}
-            />
-            {refError && (
-              <div className="profile-option-control-error">{refError}</div>
-            )}
-          </div>
+      <div
+        className={`profile-option-container ${repoError ? "has-error" : ""}`}
+      >
+        <div className="profile-option-label-container">
+          <label>Git Ref</label>
         </div>
-      )}
+        <div className="profile-option-control-container">
+          <Select
+            aria-label="Git Ref"
+            ref={branchFieldRef}
+            {...refFieldProps}
+            aria-invalid={!!refError}
+            isDisabled={!refFieldProps.options}
+          />
+          {refIsLoading && !refIsLoading && (
+            <div className="profile-option-control-info">Loading Git ref options...</div>
+          )}
+          {refError && (
+            <div className="profile-option-control-error">{refError}</div>
+          )}
+        </div>
+      </div>
 
       <div className="right-button">
         <button

--- a/src/ImageBuilder.test.js
+++ b/src/ImageBuilder.test.js
@@ -33,7 +33,9 @@ test("select repository by org/repo", async () => {
   const branchField = await screen.getByLabelText("Branch");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
-  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+  expect(fetch.mock.calls[0][0]).toEqual(
+    "https://api.github.com/repos/org/repo",
+  );
 });
 
 test("select repository by https://github.com/org/repo", async () => {
@@ -64,7 +66,9 @@ test("select repository by https://github.com/org/repo", async () => {
   const branchField = await screen.getByLabelText("Branch");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
-  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+  expect(fetch.mock.calls[0][0]).toEqual(
+    "https://api.github.com/repos/org/repo",
+  );
 });
 
 test("select repository by https://www.github.com/org/repo", async () => {
@@ -95,7 +99,9 @@ test("select repository by https://www.github.com/org/repo", async () => {
   const branchField = await screen.getByLabelText("Branch");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
-  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+  expect(fetch.mock.calls[0][0]).toEqual(
+    "https://api.github.com/repos/org/repo",
+  );
 });
 
 test("select repository by github.com/org/repo", async () => {
@@ -126,7 +132,9 @@ test("select repository by github.com/org/repo", async () => {
   const branchField = await screen.getByLabelText("Branch");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
-  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+  expect(fetch.mock.calls[0][0]).toEqual(
+    "https://api.github.com/repos/org/repo",
+  );
 });
 
 test("select repository by www.github.com/org/repo", async () => {
@@ -157,7 +165,9 @@ test("select repository by www.github.com/org/repo", async () => {
   const branchField = await screen.getByLabelText("Branch");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
-  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+  expect(fetch.mock.calls[0][0]).toEqual(
+    "https://api.github.com/repos/org/repo",
+  );
 });
 
 test("invalid org/repo string (not matching pattern)", async () => {
@@ -182,7 +192,11 @@ test("invalid org/repo string (not matching pattern)", async () => {
   await user.type(repoField, "org");
   await user.click(document.body);
 
-  expect(screen.getByText("Provide the repository as the format 'organization/repository'."));
+  expect(
+    screen.getByText(
+      "Provide the repository as the format 'organization/repository'.",
+    ),
+  );
   expect(screen.queryByLabelText("Branch")).not.toBeInTheDocument();
 });
 
@@ -208,12 +222,16 @@ test("invalid org/repo string (wrong base URL)", async () => {
   await user.type(repoField, "example.com/org/repo");
   await user.click(document.body);
 
-  expect(screen.getByText("Provide the repository as the format 'organization/repository'."));
+  expect(
+    screen.getByText(
+      "Provide the repository as the format 'organization/repository'.",
+    ),
+  );
   expect(screen.queryByLabelText("Branch")).not.toBeInTheDocument();
 });
 
 test("repo not found", async () => {
-  fetch.mockResponseOnce("", { status: 400 })
+  fetch.mockResponseOnce("", { status: 400 });
   const user = userEvent.setup();
 
   render(
@@ -255,9 +273,13 @@ test("no org/repo provided", async () => {
   await user.click(select);
 
   await user.click(screen.getByText("Build your own image"));
-  await user.click(screen.getByRole("button", { name: "Build image" }))
+  await user.click(screen.getByRole("button", { name: "Build image" }));
 
-  expect(screen.getByText("Provide the repository as the format 'organization/repository'."));
+  expect(
+    screen.getByText(
+      "Provide the repository as the format 'organization/repository'.",
+    ),
+  );
 });
 
 test("no branch selected", async () => {
@@ -286,7 +308,7 @@ test("no branch selected", async () => {
   await user.click(document.body);
 
   expect(screen.queryByLabelText("Branch")).toBeInTheDocument();
-  await user.click(screen.getByRole("button", { name: "Build image" }))
+  await user.click(screen.getByRole("button", { name: "Build image" }));
 
   expect(screen.getByText("Select a branch."));
 });

--- a/src/ImageBuilder.test.js
+++ b/src/ImageBuilder.test.js
@@ -1,0 +1,292 @@
+import { expect, test } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ProfileForm from "./ProfileForm";
+import { SpawnerFormProvider } from "./state";
+
+test("select repository by org/repo", async () => {
+  fetch
+    .mockResponseOnce("")
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "org/repo");
+  await user.click(document.body);
+
+  const branchField = await screen.getByLabelText("Branch");
+  await user.click(branchField);
+  await user.click(screen.getByText("main"));
+  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+});
+
+test("select repository by https://github.com/org/repo", async () => {
+  fetch
+    .mockResponseOnce("")
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "https://github.com/org/repo");
+  await user.click(document.body);
+
+  const branchField = await screen.getByLabelText("Branch");
+  await user.click(branchField);
+  await user.click(screen.getByText("main"));
+  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+});
+
+test("select repository by https://www.github.com/org/repo", async () => {
+  fetch
+    .mockResponseOnce("")
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "https://www.github.com/org/repo");
+  await user.click(document.body);
+
+  const branchField = await screen.getByLabelText("Branch");
+  await user.click(branchField);
+  await user.click(screen.getByText("main"));
+  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+});
+
+test("select repository by github.com/org/repo", async () => {
+  fetch
+    .mockResponseOnce("")
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "github.com/org/repo");
+  await user.click(document.body);
+
+  const branchField = await screen.getByLabelText("Branch");
+  await user.click(branchField);
+  await user.click(screen.getByText("main"));
+  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+});
+
+test("select repository by www.github.com/org/repo", async () => {
+  fetch
+    .mockResponseOnce("")
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "www.github.com/org/repo");
+  await user.click(document.body);
+
+  const branchField = await screen.getByLabelText("Branch");
+  await user.click(branchField);
+  await user.click(screen.getByText("main"));
+  expect(fetch.mock.calls[0][0]).toEqual("https://api.github.com/repos/org/repo");
+});
+
+test("invalid org/repo string (not matching pattern)", async () => {
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "org");
+  await user.click(document.body);
+
+  expect(screen.getByText("Provide the repository as the format 'organization/repository'."));
+  expect(screen.queryByLabelText("Branch")).not.toBeInTheDocument();
+});
+
+test("invalid org/repo string (wrong base URL)", async () => {
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "example.com/org/repo");
+  await user.click(document.body);
+
+  expect(screen.getByText("Provide the repository as the format 'organization/repository'."));
+  expect(screen.queryByLabelText("Branch")).not.toBeInTheDocument();
+});
+
+test("repo not found", async () => {
+  fetch.mockResponseOnce("", { status: 400 })
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "https://github.com/org/repo");
+  await user.click(document.body);
+
+  expect(screen.queryByLabelText("Branch")).not.toBeInTheDocument();
+});
+
+test("no org/repo provided", async () => {
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+  await user.click(screen.getByRole("button", { name: "Build image" }))
+
+  expect(screen.getByText("Provide the repository as the format 'organization/repository'."));
+});
+
+test("no branch selected", async () => {
+  fetch
+    .mockResponseOnce("")
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+  const user = userEvent.setup();
+
+  render(
+    <SpawnerFormProvider>
+      <ProfileForm />
+    </SpawnerFormProvider>,
+  );
+  const radio = screen.getByRole("radio", {
+    name: "CPU only No GPU, only CPU",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "org/repo");
+  await user.click(document.body);
+
+  expect(screen.queryByLabelText("Branch")).toBeInTheDocument();
+  await user.click(screen.getByRole("button", { name: "Build image" }))
+
+  expect(screen.getByText("Select a branch."));
+});

--- a/src/ImageBuilder.test.js
+++ b/src/ImageBuilder.test.js
@@ -8,7 +8,8 @@ import { SpawnerFormProvider } from "./state";
 test("select repository by org/repo", async () => {
   fetch
     .mockResponseOnce("")
-    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]))
+    .mockResponseOnce(JSON.stringify([{ name: "v1.0" }]));
   const user = userEvent.setup();
 
   render(
@@ -30,7 +31,7 @@ test("select repository by org/repo", async () => {
   await user.type(repoField, "org/repo");
   await user.click(document.body);
 
-  const branchField = await screen.getByLabelText("Branch");
+  const branchField = await screen.getByLabelText("Git Ref");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
   expect(fetch.mock.calls[0][0]).toEqual(
@@ -41,7 +42,8 @@ test("select repository by org/repo", async () => {
 test("select repository by https://github.com/org/repo", async () => {
   fetch
     .mockResponseOnce("")
-    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]))
+    .mockResponseOnce(JSON.stringify([{ name: "v1.0" }]));
   const user = userEvent.setup();
 
   render(
@@ -63,7 +65,7 @@ test("select repository by https://github.com/org/repo", async () => {
   await user.type(repoField, "https://github.com/org/repo");
   await user.click(document.body);
 
-  const branchField = await screen.getByLabelText("Branch");
+  const branchField = await screen.getByLabelText("Git Ref");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
   expect(fetch.mock.calls[0][0]).toEqual(
@@ -74,7 +76,8 @@ test("select repository by https://github.com/org/repo", async () => {
 test("select repository by https://www.github.com/org/repo", async () => {
   fetch
     .mockResponseOnce("")
-    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]))
+    .mockResponseOnce(JSON.stringify([{ name: "v1.0" }]));
   const user = userEvent.setup();
 
   render(
@@ -96,7 +99,7 @@ test("select repository by https://www.github.com/org/repo", async () => {
   await user.type(repoField, "https://www.github.com/org/repo");
   await user.click(document.body);
 
-  const branchField = await screen.getByLabelText("Branch");
+  const branchField = await screen.getByLabelText("Git Ref");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
   expect(fetch.mock.calls[0][0]).toEqual(
@@ -107,7 +110,8 @@ test("select repository by https://www.github.com/org/repo", async () => {
 test("select repository by github.com/org/repo", async () => {
   fetch
     .mockResponseOnce("")
-    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]))
+    .mockResponseOnce(JSON.stringify([{ name: "v1.0" }]));
   const user = userEvent.setup();
 
   render(
@@ -129,7 +133,7 @@ test("select repository by github.com/org/repo", async () => {
   await user.type(repoField, "github.com/org/repo");
   await user.click(document.body);
 
-  const branchField = await screen.getByLabelText("Branch");
+  const branchField = await screen.getByLabelText("Git Ref");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
   expect(fetch.mock.calls[0][0]).toEqual(
@@ -140,7 +144,8 @@ test("select repository by github.com/org/repo", async () => {
 test("select repository by www.github.com/org/repo", async () => {
   fetch
     .mockResponseOnce("")
-    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]))
+    .mockResponseOnce(JSON.stringify([{ name: "v1.0" }]));
   const user = userEvent.setup();
 
   render(
@@ -162,7 +167,7 @@ test("select repository by www.github.com/org/repo", async () => {
   await user.type(repoField, "www.github.com/org/repo");
   await user.click(document.body);
 
-  const branchField = await screen.getByLabelText("Branch");
+  const branchField = await screen.getByLabelText("Git Ref");
   await user.click(branchField);
   await user.click(screen.getByText("main"));
   expect(fetch.mock.calls[0][0]).toEqual(
@@ -197,7 +202,7 @@ test("invalid org/repo string (not matching pattern)", async () => {
       "Provide the repository as the format 'organization/repository'.",
     ),
   );
-  expect(screen.queryByLabelText("Branch")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Git Ref")).not.toBeInTheDocument();
 });
 
 test("invalid org/repo string (wrong base URL)", async () => {
@@ -227,7 +232,7 @@ test("invalid org/repo string (wrong base URL)", async () => {
       "Provide the repository as the format 'organization/repository'.",
     ),
   );
-  expect(screen.queryByLabelText("Branch")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Git Ref")).not.toBeInTheDocument();
 });
 
 test("repo not found", async () => {
@@ -253,7 +258,7 @@ test("repo not found", async () => {
   await user.type(repoField, "https://github.com/org/repo");
   await user.click(document.body);
 
-  expect(screen.queryByLabelText("Branch")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Git Ref")).not.toBeInTheDocument();
 });
 
 test("no org/repo provided", async () => {
@@ -285,7 +290,8 @@ test("no org/repo provided", async () => {
 test("no branch selected", async () => {
   fetch
     .mockResponseOnce("")
-    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]));
+    .mockResponseOnce(JSON.stringify([{ name: "main" }, { name: "develop" }]))
+    .mockResponseOnce(JSON.stringify([{ name: "v1.0" }]));
   const user = userEvent.setup();
 
   render(
@@ -307,8 +313,8 @@ test("no branch selected", async () => {
   await user.type(repoField, "org/repo");
   await user.click(document.body);
 
-  expect(screen.queryByLabelText("Branch")).toBeInTheDocument();
+  expect(screen.queryByLabelText("Git Ref")).toBeInTheDocument();
   await user.click(screen.getByRole("button", { name: "Build image" }));
 
-  expect(screen.getByText("Select a branch."));
+  expect(screen.getByText("Select a git ref."));
 });

--- a/src/ImageBuilder.test.js
+++ b/src/ImageBuilder.test.js
@@ -202,7 +202,7 @@ test("invalid org/repo string (not matching pattern)", async () => {
       "Provide the repository as the format 'organization/repository'.",
     ),
   );
-  expect(screen.queryByLabelText("Git Ref")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Git Ref")).toHaveAttribute("disabled");
 });
 
 test("invalid org/repo string (wrong base URL)", async () => {
@@ -232,7 +232,7 @@ test("invalid org/repo string (wrong base URL)", async () => {
       "Provide the repository as the format 'organization/repository'.",
     ),
   );
-  expect(screen.queryByLabelText("Git Ref")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Git Ref")).toHaveAttribute("disabled");
 });
 
 test("repo not found", async () => {
@@ -258,7 +258,7 @@ test("repo not found", async () => {
   await user.type(repoField, "https://github.com/org/repo");
   await user.click(document.body);
 
-  expect(screen.queryByLabelText("Git Ref")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Git Ref")).toHaveAttribute("disabled");
 });
 
 test("no org/repo provided", async () => {

--- a/src/form.css
+++ b/src/form.css
@@ -75,6 +75,10 @@
   border-radius: 4px;
 }
 
+.profile-option-control-info {
+  margin-top: 0.5rem;
+}
+
 .profile-option-container.has-error label {
   color: red;
 }

--- a/src/form.css
+++ b/src/form.css
@@ -97,6 +97,11 @@
   margin-top: 0.5rem;
 }
 
+.right-button {
+  text-align: right;
+  margin-bottom: 2rem;
+}
+
 /* react-select styling */
 .react-select-item-container.react-select-item-menu-display.react-select-item-selected
   .react-select-item-description {

--- a/src/hooks/useRefField.js
+++ b/src/hooks/useRefField.js
@@ -1,0 +1,49 @@
+import { useState, useEffect, useMemo } from "react";
+
+export default function useRefField(repository) {
+  const [value, setValue] = useState("");
+  const [options, setOptions] = useState();
+  const [error, setError] = useState();
+
+  const selectedOption = useMemo(() => {
+    if (!value || !options) return;
+    return options.find((option) => option.value === value);
+  }, [value]);
+
+  useEffect(() => {
+    setOptions();
+    if (repository) {
+      fetch(`https://api.github.com/repos/${repository}/branches`)
+        .then(r => {
+          if (r.ok) return r.json()
+        })
+        .then(r => {
+          const branchNames = r.map(({ name }) => ({ label: name, value: name }));
+          setOptions(branchNames);
+        })
+    }
+  }, [repository]);
+
+  const onChange = (e) => {
+    setError();
+    setValue(e.value);
+  }
+
+  const onBlur = () => {
+    setError();
+    if (!value) {
+      setError("Select a branch.")
+    }
+  }
+
+  return {
+    ref: value,
+    refError: error,
+    refFieldProps: {
+      value: selectedOption,
+      options,
+      onChange,
+      onBlur
+    }
+  }
+}

--- a/src/hooks/useRefField.js
+++ b/src/hooks/useRefField.js
@@ -14,27 +14,30 @@ export default function useRefField(repository) {
     setOptions();
     if (repository) {
       fetch(`https://api.github.com/repos/${repository}/branches`)
-        .then(r => {
-          if (r.ok) return r.json()
+        .then((r) => {
+          if (r.ok) return r.json();
         })
-        .then(r => {
-          const branchNames = r.map(({ name }) => ({ label: name, value: name }));
+        .then((r) => {
+          const branchNames = r.map(({ name }) => ({
+            label: name,
+            value: name,
+          }));
           setOptions(branchNames);
-        })
+        });
     }
   }, [repository]);
 
   const onChange = (e) => {
     setError();
     setValue(e.value);
-  }
+  };
 
   const onBlur = () => {
     setError();
     if (!value) {
-      setError("Select a branch.")
+      setError("Select a branch.");
     }
-  }
+  };
 
   return {
     ref: value,
@@ -43,7 +46,7 @@ export default function useRefField(repository) {
       value: selectedOption,
       options,
       onChange,
-      onBlur
-    }
-  }
+      onBlur,
+    },
+  };
 }

--- a/src/hooks/useRefField.js
+++ b/src/hooks/useRefField.js
@@ -26,14 +26,15 @@ export default function useRefField(repository) {
       Promise.all([
         fetchRef(repository, "branches"),
         fetchRef(repository, "tags"),
-      ]).then((results) => {
+      ])
+        .then((results) => {
           const refOptions = results.flat().map(({ name }) => ({
             label: name,
             value: name,
           }));
           setOptions(refOptions);
         })
-        .finally(() => setIsLoading(false))
+        .finally(() => setIsLoading(false));
     }
   }, [repository]);
 

--- a/src/hooks/useRefField.js
+++ b/src/hooks/useRefField.js
@@ -11,6 +11,7 @@ export default function useRefField(repository) {
   const [value, setValue] = useState("");
   const [options, setOptions] = useState();
   const [error, setError] = useState();
+  const [isLoading, setIsLoading] = useState();
 
   const selectedOption = useMemo(() => {
     if (!value || !options) return;
@@ -18,6 +19,7 @@ export default function useRefField(repository) {
   }, [value]);
 
   useEffect(() => {
+    setIsLoading(true);
     setOptions();
     if (repository) {
       Promise.all([
@@ -31,6 +33,7 @@ export default function useRefField(repository) {
           }));
           setOptions(refOptions);
         })
+        .finally(() => setIsLoading(false))
     }
   }, [repository]);
 
@@ -49,6 +52,7 @@ export default function useRefField(repository) {
   return {
     ref: value,
     refError: error,
+    refIsLoading: isLoading,
     refFieldProps: {
       value: selectedOption,
       options,

--- a/src/hooks/useRepositoryField.js
+++ b/src/hooks/useRepositoryField.js
@@ -23,8 +23,10 @@ export default function useRepositoryField() {
   const [value, setValue] = useState("");
   const [error, setError] = useState();
   const [repoId, setRepoId] = useState();
+  const [isValidating, setIsValidating] = useState(false);
 
   const validate = async () => {
+    setIsValidating(true)
     setError();
     const orgRepoString = extractOrgAndRepo(value);
 
@@ -37,7 +39,9 @@ export default function useRepositoryField() {
       {
         method: "HEAD",
       },
-    ).then((r) => r.ok);
+    )
+      .then((r) => r.ok)
+      .finally(() => setIsValidating(false));
 
     if (!repoExists) {
       return "The repository doesn't exist or is not public.";
@@ -62,6 +66,7 @@ export default function useRepositoryField() {
     repo: value,
     repoError: error,
     repoId,
+    repoIsValidating: isValidating,
     repoFieldProps: {
       value,
       onChange,

--- a/src/hooks/useRepositoryField.js
+++ b/src/hooks/useRepositoryField.js
@@ -7,7 +7,10 @@ function extractOrgAndRepo(value) {
   if (orgRepoMatch) {
     orgRepoString = orgRepoMatch[0];
   } else {
-    const fullUrlMatch = /^(?:https?:\/\/)?(?:www\.)?github\.com\/((?:[^/]+\/[^/]+|[^/]+\/[^/]+)?)\/?$/.exec(value);
+    const fullUrlMatch =
+      /^(?:https?:\/\/)?(?:www\.)?github\.com\/((?:[^/]+\/[^/]+|[^/]+\/[^/]+)?)\/?$/.exec(
+        value,
+      );
     if (fullUrlMatch) {
       orgRepoString = fullUrlMatch[1];
     }
@@ -26,15 +29,18 @@ export default function useRepositoryField() {
     const orgRepoString = extractOrgAndRepo(value);
 
     if (!orgRepoString) {
-      return "Provide the repository as the format 'organization/repository'."
+      return "Provide the repository as the format 'organization/repository'.";
     }
 
-    const repoExists = await fetch(`https://api.github.com/repos/${orgRepoString}`, {
-      method: "HEAD"
-    }).then(r => r.ok)
+    const repoExists = await fetch(
+      `https://api.github.com/repos/${orgRepoString}`,
+      {
+        method: "HEAD",
+      },
+    ).then((r) => r.ok);
 
     if (!repoExists) {
-      return "The repository doesn't exist or is not public."
+      return "The repository doesn't exist or is not public.";
     }
   };
 
@@ -46,11 +52,11 @@ export default function useRepositoryField() {
     setRepoId();
     const err = await validate();
     if (err) {
-      setError(err)
+      setError(err);
     } else {
       setRepoId(extractOrgAndRepo(value));
     }
-  }, [value])
+  }, [value]);
 
   return {
     repo: value,
@@ -59,7 +65,7 @@ export default function useRepositoryField() {
     repoFieldProps: {
       value,
       onChange,
-      onBlur
-    }
-  }
+      onBlur,
+    },
+  };
 }

--- a/src/hooks/useRepositoryField.js
+++ b/src/hooks/useRepositoryField.js
@@ -26,7 +26,7 @@ export default function useRepositoryField() {
   const [isValidating, setIsValidating] = useState(false);
 
   const validate = async () => {
-    setIsValidating(true)
+    setIsValidating(true);
     setError();
     const orgRepoString = extractOrgAndRepo(value);
 

--- a/src/hooks/useRepositoryField.js
+++ b/src/hooks/useRepositoryField.js
@@ -1,0 +1,65 @@
+import { useCallback, useState } from "react";
+
+function extractOrgAndRepo(value) {
+  let orgRepoString;
+  const orgRepoMatch = /^[^/]+\/[^/]+$/.exec(value);
+
+  if (orgRepoMatch) {
+    orgRepoString = orgRepoMatch[0];
+  } else {
+    const fullUrlMatch = /^(?:https?:\/\/)?(?:www\.)?github\.com\/((?:[^/]+\/[^/]+|[^/]+\/[^/]+)?)\/?$/.exec(value);
+    if (fullUrlMatch) {
+      orgRepoString = fullUrlMatch[1];
+    }
+  }
+
+  return orgRepoString;
+}
+
+export default function useRepositoryField() {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState();
+  const [repoId, setRepoId] = useState();
+
+  const validate = async () => {
+    setError();
+    const orgRepoString = extractOrgAndRepo(value);
+
+    if (!orgRepoString) {
+      return "Provide the repository as the format 'organization/repository'."
+    }
+
+    const repoExists = await fetch(`https://api.github.com/repos/${orgRepoString}`, {
+      method: "HEAD"
+    }).then(r => r.ok)
+
+    if (!repoExists) {
+      return "The repository doesn't exist or is not public."
+    }
+  };
+
+  const onChange = useCallback((e) => {
+    setValue(e.target.value);
+  }, []);
+
+  const onBlur = useCallback(async () => {
+    setRepoId();
+    const err = await validate();
+    if (err) {
+      setError(err)
+    } else {
+      setRepoId(extractOrgAndRepo(value));
+    }
+  }, [value])
+
+  return {
+    repo: value,
+    repoError: error,
+    repoId,
+    repoFieldProps: {
+      value,
+      onChange,
+      onBlur
+    }
+  }
+}


### PR DESCRIPTION
Contributes to #66: Extends the build-image form, so users can select a repository and branch, and add stronger validation for inputs.

Changes

- Adds a "Repository" field, which takes the repository for the image build.
  - It can be provided either as `org/repo` or `github.com/org/repo` or `https://github.com/org/repo`. Other inputs should be rejected with an error. 
  - The entered repo is further validated against the Github API. We're sending a `HEAD` request to verify if the repository exists and if it is public. 
- Adds a "Branch" field, allowing users to select the branch to build from. 
  - The branch field will only be shown after the repository input has been verified.
  - We're using the GitHub API to request a list of available branches, the select field is populated from the list of branches. 
- Adds a placeholder for "Provider", at the moment this only says "GitHub"