### PR TITLE
Center labels on the profile form

### DIFF
--- a/src/form.css
+++ b/src/form.css
@@ -43,7 +43,7 @@
 
 .profile-option-label-container {
   grid-column-start: 1;
-  align-self: start;
+  align-self: center;
 }
 
 .profile-option-control-container {


### PR DESCRIPTION
Before:

<img width="867" alt="image" src="https://github.com/user-attachments/assets/9471f30d-a9b5-452c-9f5a-c92cd11ad646">


After:

<img width="915" alt="image" src="https://github.com/user-attachments/assets/38252828-500e-4df4-9fd9-cd879fca547a">
