### PR TITLE
Disable build-image button while building

### DIFF
--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -49,7 +49,6 @@ async function buildImage(repo, ref, term, fitAddon) {
         default: {
           console.log("Unknown phase in response from server");
           console.log(data);
-          reject();
           break;
         }
       }


### PR DESCRIPTION
Fixes #76 

- Adds new state `isBuildingImage`, which is used to set the `disabled` property of the build-image button
- ~Wraps the image-build state handling in a `Promise`, which we return from `buildImage`. This makes it easier in the `ImageBuilder` component to handle state updates, without having to pass callbacks to `buildImage`~
- Return Promises instead of using callback function, to make it easier in the `ImageBuilder` component to handle state updates