### PR TITLE
Initialise form values with empty string

### DIFF
--- a/src/hooks/useRefField.js
+++ b/src/hooks/useRefField.js
@@ -9,7 +9,7 @@ function fetchRef(repository, refType) {
 }
 
 export default function useRefField(repository, defaultValue) {
-  const [value, setValue] = useState(defaultValue);
+  const [value, setValue] = useState(defaultValue || "");
   const [options, setOptions] = useState();
   const [error, setError] = useState();
   const [isLoading, setIsLoading] = useState();

--- a/src/hooks/useRepositoryField.js
+++ b/src/hooks/useRepositoryField.js
@@ -20,7 +20,7 @@ function extractOrgAndRepo(value) {
 }
 
 export default function useRepositoryField(defaultValue) {
-  const [value, setValue] = useState(defaultValue);
+  const [value, setValue] = useState(defaultValue || "");
   const [error, setError] = useState();
   const [repoId, setRepoId] = useState();
   const [isValidating, setIsValidating] = useState(false);


### PR DESCRIPTION
Fixes a small issue when initialising the image-builder form fields: If there's no default value, the field will be initialised with `undefined`, which is an anti-pattern. Fixing this by supplying an empty string if the `defaultValue` is `undefined`. 