### PR TITLE
Select profile even if the user clicks on the padding area

### DIFF
--- a/src/ProfileForm.jsx
+++ b/src/ProfileForm.jsx
@@ -62,7 +62,12 @@ function Form() {
         return (
           <div
             key={slug}
-            className={`profile-select ${selectedProfile?.slug === slug ? "selected-profile" : ""}`}
+            className={`profile-select ${
+              selectedProfile?.slug === slug ? "selected-profile" : ""
+            }`}
+            onClick={() => {
+              setProfile(slug);
+            }}
           >
             {profileList.length > 1 && (
               <input
@@ -76,12 +81,7 @@ function Form() {
                 aria-labelledby={`profile-option-${slug}-label`}
               />
             )}
-            <div
-              className="profile-select-body"
-              onClick={() => {
-                setProfile(slug);
-              }}
-            >
+            <div className="profile-select-body">
               <div
                 id={`profile-option-${slug}-label`}
                 className="profile-select-label"


### PR DESCRIPTION
The hitbox for what was selecting the profile was smaller without this change. With this change, we now match what the default kubespawner experience is.

Ref https://github.com/yuvipanda/jupyterhub-fancy-profiles/issues/40