### PR TITLE
Ensure default choice is selected

### DIFF
--- a/src/hooks/useSelectOptions.js
+++ b/src/hooks/useSelectOptions.js
@@ -29,9 +29,9 @@ function useSelectOptions(config, customOptions = []) {
   // OR the first item from options which could be an extra or custom choice
   const defaultChoiceName =
     Object.keys(choices).find((choiceName) => choices[choiceName].default) ||
-    Object.keys(choices).length > 0
+    (Object.keys(choices).length > 0
       ? Object.keys(choices)[0]
-      : options[0].value;
+      : options[0].value);
 
   const defaultOption = options.find(
     (option) => option.value === defaultChoiceName,


### PR DESCRIPTION
Fixes #84 

Fixes the boolean logic used to determine the default choice. Previously, the logic looked similar to

```
"a" || someVar > 1 ? "b" : "c"
```

which always results in "b" because it's evaluated like (see the parentheses): 

```
("a" || someVar > 1) ? "b" : "c"
```

By wrapping the `if` shorthand in parentheses, we make sure it's evaluated as "either a, or whatever the result of the `if` shorthand.

```
"a" || (someVar > 1 ? "b" : "c")
```