### PR TITLE
Add hint text for ref field

### DIFF
--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -178,6 +178,7 @@ export function ImageBuilder({ name, isActive }) {
         ref={branchFieldRef}
         id={`${name}--ref`}
         label="Git Ref"
+        hint="Branch, Tag or Commit to use. HEAD will use the default branch"
         value={ref}
         validate={
           isActive && {

--- a/src/components/form/fields.jsx
+++ b/src/components/form/fields.jsx
@@ -27,7 +27,9 @@ function Field({ id, label, hint, children, error }) {
       </div>
       <div className="profile-option-control-container">
         {children}
-        {(hint && !error) && <div className="profile-option-control-hint">{hint}</div>}
+        {hint && !error && (
+          <div className="profile-option-control-hint">{hint}</div>
+        )}
         {error && <div className="profile-option-control-error">{error}</div>}
       </div>
     </div>

--- a/src/components/form/fields.jsx
+++ b/src/components/form/fields.jsx
@@ -27,10 +27,8 @@ function Field({ id, label, hint, children, error }) {
       </div>
       <div className="profile-option-control-container">
         {children}
-        {hint && !error && (
-          <div className="profile-option-control-hint">{hint}</div>
-        )}
         {error && <div className="profile-option-control-error">{error}</div>}
+        {hint && <div className="profile-option-control-hint">{hint}</div>}
       </div>
     </div>
   );

--- a/src/components/form/fields.jsx
+++ b/src/components/form/fields.jsx
@@ -19,7 +19,7 @@ function validateField(value, validateConfig, touched) {
   return;
 }
 
-function Field({ id, label, children, error }) {
+function Field({ id, label, hint, children, error }) {
   return (
     <div className={`profile-option-container ${error ? "has-error" : ""}`}>
       <div className="profile-option-label-container">
@@ -27,7 +27,7 @@ function Field({ id, label, children, error }) {
       </div>
       <div className="profile-option-control-container">
         {children}
-
+        {(hint && !error) && <div className="profile-option-control-hint">{hint}</div>}
         {error && <div className="profile-option-control-error">{error}</div>}
       </div>
     </div>
@@ -37,6 +37,7 @@ function Field({ id, label, children, error }) {
 export function SelectField({
   id,
   label,
+  hint,
   options,
   defaultOption,
   onChange,
@@ -55,7 +56,7 @@ export function SelectField({
   );
 
   return (
-    <Field id={id} label={label} error={error}>
+    <Field id={id} label={label} hint={hint} error={error}>
       <CustomizedSelect
         options={options}
         id={id}
@@ -74,7 +75,7 @@ export function SelectField({
 }
 
 function _TextField(
-  { id, label, value, validate = {}, onChange, tabIndex },
+  { id, label, value, hint, validate = {}, onChange, tabIndex },
   ref,
 ) {
   const [touched, setTouched] = useState(false);
@@ -85,7 +86,7 @@ function _TextField(
   const error = validateField(value, validate, touched);
 
   return (
-    <Field id={id} label={label} error={touched && error}>
+    <Field id={id} label={label} hint={hint} error={touched && error}>
       <input
         ref={ref}
         type="text"

--- a/src/form.css
+++ b/src/form.css
@@ -90,13 +90,13 @@
 .profile-option-control-hint {
   color: #555;
   margin-top: 0.3rem;
-  font-size: .9rem;
+  font-size: 0.9rem;
 }
 
 .profile-option-control-error {
   color: red;
   margin-top: 0.3rem;
-  font-size: .9rem;
+  font-size: 0.9rem;
 }
 
 .profile-form-error {

--- a/src/form.css
+++ b/src/form.css
@@ -87,9 +87,16 @@
   border-color: red;
 }
 
+.profile-option-control-hint {
+  color: #555;
+  margin-top: 0.3rem;
+  font-size: .9rem;
+}
+
 .profile-option-control-error {
   color: red;
-  margin-top: 0.5rem;
+  margin-top: 0.3rem;
+  font-size: .9rem;
 }
 
 .profile-form-error {


### PR DESCRIPTION
Resolves #92 

- Adds `hint` prop to `TextField` and the generic `Field` component. The hint is rendered only where there's no error on the field.
- Add `profile-option-control-hint` css class to style the hint
- Adapt spacing and font size of `profile-option-control-error` so it's in line with the new hint class