### PR TITLE
Fetch ApiToken before intialising image build

### DIFF
--- a/binderhub_config.py
+++ b/binderhub_config.py
@@ -4,6 +4,8 @@ c = get_config()  # noqa
 # Enable debug logs for binderhub itself
 c.BinderHub.debug = True
 
+c.BinderHub.auth_enabled = True
+
 # Just leave the built image in the node, so our hub can launch it
 c.BinderHub.use_registry = False
 

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -28,7 +28,18 @@ c.JupyterHub.services = [
         "command": ["python", "-m", "binderhub", "-f", "binderhub_config.py"],
         # Pass on environment variables required for binderhub to find where the docker image is
         "environment": os.environ.copy(),
+        "oauth_client_id": "service-binderhub",
+        "oauth_no_confirm": True,
+        "oauth_redirect_uri": "http://localhost:8585/oauth_callback"        
     }
+]
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "user",
+        # grant all users access to services
+        "scopes": ["self", "access:services"],
+    },
 ]
 
 # Find the IP of the machine that minikube is most likely able to talk to

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@jupyterhub/binderhub-client": "0.4.0",
+        "@jupyterhub/binderhub-client": "^0.5.0",
         "configurable-http-proxy": "^4.6.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2908,17 +2908,23 @@
       }
     },
     "node_modules/@jupyterhub/binderhub-client": {
-      "version": "0.4.0",
-      "license": "BSD-3-Clause",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@jupyterhub/binderhub-client/-/binderhub-client-0.5.0.tgz",
+      "integrity": "sha512-JkkZTTnjlWJi1GQ8AR/mURqYCUJPnSiLZAHE26TN6ItFxWVfDsF3uyWCxbJQnwXPlc8vBW6/JPd4gkIlWfo88w==",
       "dependencies": {
-        "event-iterator": "^2.0.0",
-        "event-source-polyfill": "^1.0.31"
+        "@microsoft/fetch-event-source": "^2.0.1",
+        "event-iterator": "^2.0.0"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6317,10 +6323,6 @@
     },
     "node_modules/event-iterator": {
       "version": "2.0.0",
-      "license": "MIT"
-    },
-    "node_modules/event-source-polyfill": {
-      "version": "1.0.31",
       "license": "MIT"
     },
     "node_modules/eventemitter3": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint 'src/**/*.ts' 'src/**/*.tsx' --fix"
   },
   "dependencies": {
-    "@jupyterhub/binderhub-client": "0.4.0",
+    "@jupyterhub/binderhub-client": "^0.5.0",
     "configurable-http-proxy": "^4.6.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -57,7 +57,7 @@ async function buildImage(
 ) {
   const apiToken = await getApiToken();
 
-  // @ts-ignore - v0.5.0 client types not available
+  // @ts-expect-error - v0.5.0 client types not available
   const { BinderRepository } = await import("@jupyterhub/binderhub-client/client.js");
   const providerSpec = "gh/" + repo + "/" + ref;
   // FIXME: Assume the binder api is available in the same hostname, under /services/binder/

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -57,7 +57,8 @@ async function buildImage(
 ) {
   const apiToken = await getApiToken();
 
-  const { BinderRepository } = await import("@jupyterhub/binderhub-client");
+  // @ts-ignore - v0.5.0 client types not available
+  const { BinderRepository } = await import("@jupyterhub/binderhub-client/client.js");
   const providerSpec = "gh/" + repo + "/" + ref;
   // FIXME: Assume the binder api is available in the same hostname, under /services/binder/
   const buildEndPointURL = new URL(
@@ -65,11 +66,14 @@ async function buildImage(
     window.location.origin,
   );
 
+  // Use new v0.5.0 API with options object - only apiToken needed for auth
   const image = new BinderRepository(
     providerSpec,
     buildEndPointURL,
-    apiToken,
-    true,
+    {
+      apiToken,     // JupyterHub API token for Authorization header
+      buildOnly: true,
+    }
   );
   // Clear the last line written, so we start from scratch
   term.write("\x1b[2K\r");

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -21,10 +21,30 @@ async function buildImage(
     "/services/binder/build/",
     window.location.origin,
   );
+
+  const xsrfToken = (`; ${document.cookie}`).split("; _xsrf=").pop().split(";")[0];
+  const userResponse = await fetch(`/hub/api/user?_xsrf=${xsrfToken}`);
+  const { name } = await userResponse.json();
+
+  const tokenResponse = await fetch(`/hub/api/users/${name}/tokens?_xsrf=${xsrfToken}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      expires_in: 3600,
+      note: "Build-image token"
+    }),
+    credentials: "include"
+  });
+  const { token } = await tokenResponse.json();
+
   const image = new BinderRepository(
     providerSpec,
     buildEndPointURL,
-    null,
+    {
+      apiToken: token
+    },
     true,
   );
   // Clear the last line written, so we start from scratch

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -68,9 +68,7 @@ async function buildImage(
   const image = new BinderRepository(
     providerSpec,
     buildEndPointURL,
-    {
-      apiToken
-    },
+    apiToken,
     true,
   );
   // Clear the last line written, so we start from scratch

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -40,7 +40,7 @@ async function getApiToken () {
     },
     body: JSON.stringify({
       expires_in: 3600,
-      note: "Build-image token"
+      note: "Created by Fancy Profiles for Build your Own Image"
     }),
     credentials: "include"
   });


### PR DESCRIPTION
Adds functionality to fetch an API token and pass that on to the image builder. 

At the moment we're fetching a new token for each new build. The better option will be to:

- Store the token in session storage or local storage
- Before fetching a new token, check if we have a token already that hasn't expired and use that
- Otherwise fetch and store a new token

I can add that as well...