### PR TITLE
Remove reference to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,6 @@ We should release early and often!
 
 4. That's it! A new release should be on PyPI shortly.
 
-## Contribute to documentation
-
-Our documentation is located in the `docs/` folder.
-
-It is built with the [MyST Document Engine](https://mystmd.org).
-
-It is deployed with [a GitHub Action](./.github/workflows/docs.yml), and [we use ReadTheDocs](./readthedocs.yml) just for PR previews.
 
 ## Comparisons to the BinderHub UI
 


### PR DESCRIPTION
We don't have a docs site with any content yet, and I've now seen two people be confused by it.