### PR TITLE
Add autostart, Consolidation of build Image and start buttons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG Z2JH_VERSION=4.3.1
 # then copy over just the built wheel files for the final image.
 # This keeps image size low while also making the whole process
 # reasonably simple
-FROM quay.io/jupyterhub/k8s-hub:${Z2JH_VERSION} as builder
+FROM quay.io/jupyterhub/k8s-hub:${Z2JH_VERSION} AS builder
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Here are some quick links:
 
 1. **Enhanced Profile Selection** - Better looking UI for KubeSpawner's `profileList` with rich descriptions
 2. **Dynamic Image Building** - Optional integration with BinderHub to build images on-demand
+3. **Permalinkes and Auto-Start** - Automatically start pre-defined environments via permalinks.
 
 See the [User Guide](./docs/guide.md) for more details.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here are some quick links:
 
 1. **Enhanced Profile Selection** - Better looking UI for KubeSpawner's `profileList` with rich descriptions
 2. **Dynamic Image Building** - Optional integration with BinderHub to build images on-demand
-3. **Permalinkes and Auto-Start** - Automatically start pre-defined environments via permalinks.
+3. **Permalinks and Auto-Start** - Automatically start pre-defined environments via permalinks.
 
 See the [User Guide](./docs/guide.md) for more details.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -12,6 +12,8 @@ The package interprets your existing KubeSpawner `profile_list` configuration an
 - Better looking and more featureful interface
 - Descriptions for various options
 - Better descriptions for "write-in" choices
+- Permalink generation for pre-selected profile configurations
+- Auto-Start via Permalink Feature
 
 You configure profiles the same way as standard KubeSpawner—`jupyterhub-fancy-profiles` provides the enhanced UI!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,11 @@ When enabled, integrates with BinderHub (deployed as a JupyterHub service) to al
 :::
 
 :::{card} ⚙️ Standard KubeSpawner config
-Works with your existing KubeSpawner configuration—no need to change how you define profiles.
+Works with your existing KubeSpawner configuration, no need to change how you define profiles.
+:::
+
+:::{card} 🔗 Auto-start permalinks
+Generate shareable URLs that automatically launch servers with pre-configured options, perfect for workshops, courses, or shared environments.
 :::
 
 ::::
@@ -82,6 +86,96 @@ View source and report issues
 - Educational platforms with different course-specific setups
 - Organizations letting users customize their computational resources
 - Deployments integrating dynamic image building from repositories
+
+---
+
+## Auto-start feature
+
+The auto-start feature allows you to create shareable URLs that automatically launch a JupyterHub server with pre-configured settings. This is particularly useful for:
+
+- **Workshops and tutorials**: Provide participants with a link that starts their environment with the exact configuration needed
+- **Course materials**: Embed links in course content that launch students directly into the right environment
+- **Shared environments**: Create standardized setups for teams or projects
+
+### How it works
+
+1. Configure your desired server options in the profile form (profile type, image, resources, etc.)
+2. Click the "Copy Link" button to copy a permalink to your clipboard
+3. The copied URL includes `autoStart=false` by default, change this to `autoStart=true` in the URL to enable automatic launching
+4. Share the URL with others or bookmark it for yourself
+
+When someone visits a URL with `autoStart=true`, the form will automatically populate with the saved configuration and submit itself after a brief timeout, launching the server immediately.
+
+```{tip}
+The permalink button automatically sets `autoStart=false` to make it easy to create auto-start URLs. Simply change `false` to `true` in the copied URL to enable the auto-start behavior.
+```
+
+### Advanced: Combining with nbgitpuller URLs
+
+If your JupyterHub environment has [nbgitpuller](https://github.com/jupyterhub/nbgitpuller) installed, you can combine auto-start permalinks with git-pull functionality to create URLs that both clone a repository and launch a pre-configured server. The nbgitpuller extension enables the `/hub/user-redirect/git-pull` URLs and automatically handles login redirects.
+
+This is especially useful for distributing workshop materials or course notebooks where you want participants to have both the right environment and the right content.
+
+Here's a Python script that generates such URLs:
+
+```python
+import urllib.parse
+import re
+
+# Configuration
+notebook_url = "https://github.com/org/repo/blob/branch/notebooks/example.ipynb"
+permalink = ""  # Permalink copied from fancy profiles form
+jupyterhub_url = "https://jupyterhub.example.org"
+
+# Extract repository information from notebook URL
+git_repo_url = notebook_url.split("/blob/")[0]
+branch = notebook_url.split("/blob/")[1].split("/")[0]
+notebook_path = "/".join(notebook_url.split("/blob/")[1].split("/")[1:])
+notebook_suburl = git_repo_url.split("/")[-1] + "/" + notebook_path
+
+# Build git-pull URL (requires nbgitpuller)
+gitpull_next = (
+    f"/hub/user-redirect/git-pull"
+    f"?repo={git_repo_url}"
+    f"&branch={branch}"
+    f"&urlpath=lab/tree/{notebook_suburl}"
+)
+
+# Build spawn URL with git-pull as next parameter
+spawn_next = "/hub/spawn?next=" + urllib.parse.quote(gitpull_next, safe="")
+
+# Extract fancy-forms-config from permalink and enable auto-start
+config_match = re.search(r"%23.+?(?=%7D)", permalink)
+if config_match:
+    fancy_forms_config = config_match[0].replace(
+        "%22autoStart%22%3A%22false%22",
+        "%22autoStart%22%3A%22true%22"
+    )
+    # Construct final URL
+    final_url = (
+        f"{jupyterhub_url}/hub/login"
+        f"?next={urllib.parse.quote(spawn_next, safe='')}"
+        f"{fancy_forms_config}%7D"
+    )
+    print(final_url)
+else:
+    print("Error: Could not extract config from permalink")
+```
+
+**How it works:**
+
+1. The script extracts the git repository URL and branch from a GitHub notebook URL
+2. It creates a git-pull URL that clones the repository and opens the specified notebook (enabled by nbgitpuller)
+3. It combines this with the fancy profiles configuration from your permalink
+4. It sets `autoStart=true` to automatically launch the server
+5. The nbgitpuller extension handles the login redirect flow automatically
+6. The result is a single URL that authenticates users, clones the repository, configures the server environment, and launches it automatically
+
+```{note}
+This requires [nbgitpuller](https://github.com/jupyterhub/nbgitpuller) to be installed in your JupyterHub environment. nbgitpuller provides the `/hub/user-redirect/git-pull` endpoint and handles the authentication redirect flow.
+```
+
+**Example use case:** Share a link with workshop participants that gives them the right computational environment and opens the workshop notebook automatically.
 
 ---
 

--- a/setupTests.js
+++ b/setupTests.js
@@ -5,6 +5,19 @@ fetchMock.enableMocks();
 
 HTMLCanvasElement.prototype.getContext = () => {};
 
+// jsdom doesn't expose crypto.randomUUID or structuredClone, but fake-indexeddb needs them
+if (!globalThis.crypto?.randomUUID) {
+  const nodeCrypto = require("crypto");
+  Object.defineProperty(globalThis.crypto, "randomUUID", {
+    value: nodeCrypto.randomUUID.bind(nodeCrypto),
+    configurable: true,
+    writable: true,
+  });
+}
+if (typeof globalThis.structuredClone !== "function") {
+  globalThis.structuredClone = (obj) => JSON.parse(JSON.stringify(obj));
+}
+
 // Mock window.scrollTo
 window.scrollTo = jest.fn();
 

--- a/setupTests.js
+++ b/setupTests.js
@@ -4,6 +4,10 @@ import fetchMock from "jest-fetch-mock";
 fetchMock.enableMocks();
 
 HTMLCanvasElement.prototype.getContext = () => {};
+
+// Mock window.scrollTo
+window.scrollTo = jest.fn();
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: jest.fn().mockImplementation((query) => ({

--- a/src/ImageBuilder.test.tsx
+++ b/src/ImageBuilder.test.tsx
@@ -8,7 +8,11 @@ import renderWithContext from "./test/renderWithContext";
 test("select repository by org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -33,7 +37,11 @@ test("select repository by org/repo", async () => {
 test("select repository by https://github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -58,7 +66,11 @@ test("select repository by https://github.com/org/repo", async () => {
 test("select repository by https://www.github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -83,7 +95,11 @@ test("select repository by https://www.github.com/org/repo", async () => {
 test("select repository by github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -108,7 +124,11 @@ test("select repository by github.com/org/repo", async () => {
 test("select repository by www.github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -132,7 +152,11 @@ test("select repository by www.github.com/org/repo", async () => {
 test("invalid org/repo string (not matching pattern)", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -157,7 +181,11 @@ test("invalid org/repo string (not matching pattern)", async () => {
 test("invalid org/repo string (wrong base URL)", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -182,7 +210,11 @@ test("invalid org/repo string (wrong base URL)", async () => {
 test("no org/repo provided", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -192,7 +224,7 @@ test("no org/repo provided", async () => {
   await user.click(select);
 
   await user.click(screen.getByText("Build your own image"));
-  await user.click(screen.getByRole("button", { name: "Build image" }));
+  await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
 
   expect(
     screen.getByText(
@@ -204,7 +236,11 @@ test("no org/repo provided", async () => {
 test("no branch selected", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(
+    <form>
+      <ProfileForm />
+    </form>
+  );
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -220,7 +256,7 @@ test("no branch selected", async () => {
   await user.click(document.body);
 
   await user.clear(screen.queryByLabelText("Git Ref"));
-  await user.click(screen.getByRole("button", { name: "Build image" }));
+  await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
 
   expect(screen.getByText("Enter a git ref."));
 });

--- a/src/ImageBuilder.test.tsx
+++ b/src/ImageBuilder.test.tsx
@@ -1,9 +1,48 @@
 import { expect, test } from "@jest/globals";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import fetchMock from "jest-fetch-mock";
 
 import ProfileForm from "./ProfileForm";
 import renderWithContext, { renderWithJupyterForm } from "./test/renderWithContext";
+
+jest.mock("xterm", () => ({
+  Terminal: jest.fn().mockImplementation(() => ({
+    write: jest.fn(),
+    loadAddon: jest.fn(),
+    open: jest.fn(),
+    resize: jest.fn(),
+  })),
+}));
+
+jest.mock("xterm-addon-fit", () => ({
+  FitAddon: jest.fn().mockImplementation(() => ({
+    fit: jest.fn(),
+  })),
+}));
+
+jest.mock("@jupyterhub/binderhub-client/client.js", () => ({
+  BinderRepository: jest.fn().mockImplementation(() => ({
+    fetch: jest.fn().mockReturnValue({
+      [Symbol.asyncIterator]() {
+        let done = false;
+        return {
+          next() {
+            if (!done) {
+              done = true;
+              return Promise.resolve({
+                value: { phase: "ready", imageName: "ghcr.io/org/repo:abc123" },
+                done: false,
+              });
+            }
+            return Promise.resolve({ value: undefined, done: true });
+          },
+        };
+      },
+    }),
+    close: jest.fn(),
+  })),
+}));
 
 test("select repository by org/repo", async () => {
   const user = userEvent.setup();
@@ -268,4 +307,49 @@ test("no branch selected", async () => {
   await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
 
   expect(screen.getAllByText("Enter a git ref.").length).toBeGreaterThan(0);
+});
+
+test("build image and start submits form on first click with image name in hidden input", async () => {
+  // Pre-load a valid API token so getApiToken returns without requesting a new one.
+  // The "jupytherhub" typo matches the TOKEN_KEY constant in ImageBuilder.tsx.
+  localStorage.setItem("jupytherhub-build-token", JSON.stringify({
+    id: "test-id",
+    expires_at: "2099-01-01T00:00:00Z",
+    token: "test-token",
+  }));
+  // getApiToken always fetches /hub/api/user first, even when a cached token exists
+  fetchMock.mockResponseOnce(JSON.stringify({ name: "testuser" }));
+
+  const user = userEvent.setup();
+  const { container } = renderWithJupyterForm(<ProfileForm />);
+
+  const radio = screen.getByRole("radio", {
+    name: "Build custom environment Dynamic Image building + unlisted choice",
+  });
+  await user.click(radio);
+
+  const select = screen.getByLabelText("Image - dynamic image building");
+  await user.click(select);
+  await user.click(screen.getByText("Build your own image"));
+
+  const repoField = screen.getByLabelText("Repository");
+  await user.type(repoField, "org/repo");
+  await user.click(document.body); // triggers blur → sets repoId
+
+  const form = container.querySelector("form");
+  let hiddenValueAtSubmit = "";
+  const requestSubmitSpy = jest.spyOn(form, "requestSubmit").mockImplementation(() => {
+    const input = form.querySelector("[data-dynamic-build='true']") as HTMLInputElement;
+    hiddenValueAtSubmit = input?.value ?? "";
+  });
+
+  await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
+
+  // Build should complete and form should submit in this single click.
+  // If flushSync is missing, the hidden input still has value="" at submit time.
+  await waitFor(() => expect(requestSubmitSpy).toHaveBeenCalledTimes(1));
+  expect(hiddenValueAtSubmit).toBe("ghcr.io/org/repo:abc123");
+
+  localStorage.removeItem("jupytherhub-build-token");
+  requestSubmitSpy.mockRestore();
 });

--- a/src/ImageBuilder.test.tsx
+++ b/src/ImageBuilder.test.tsx
@@ -3,16 +3,12 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ProfileForm from "./ProfileForm";
-import renderWithContext from "./test/renderWithContext";
+import renderWithContext, { renderWithJupyterForm } from "./test/renderWithContext";
 
 test("select repository by org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -37,11 +33,7 @@ test("select repository by org/repo", async () => {
 test("select repository by https://github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -66,11 +58,7 @@ test("select repository by https://github.com/org/repo", async () => {
 test("select repository by https://www.github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -95,11 +83,7 @@ test("select repository by https://www.github.com/org/repo", async () => {
 test("select repository by github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -124,11 +108,7 @@ test("select repository by github.com/org/repo", async () => {
 test("select repository by www.github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -152,11 +132,7 @@ test("select repository by www.github.com/org/repo", async () => {
 test("invalid org/repo string (not matching pattern)", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -181,7 +157,7 @@ test("invalid org/repo string (not matching pattern)", async () => {
 test("repofield trims leading/trailing spaces", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<form><ProfileForm /></form>);
+  renderWithJupyterForm(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -203,7 +179,7 @@ test("repofield trims leading/trailing spaces", async () => {
 test("ref trims leading/trailing spaces", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<form><ProfileForm /></form>);
+  renderWithJupyterForm(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -226,11 +202,7 @@ test("ref trims leading/trailing spaces", async () => {
 test("invalid org/repo string (wrong base URL)", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithJupyterForm(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -255,11 +227,7 @@ test("invalid org/repo string (wrong base URL)", async () => {
 test("no org/repo provided", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithJupyterForm(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -281,11 +249,7 @@ test("no org/repo provided", async () => {
 test("no branch selected", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(
-    <form>
-      <ProfileForm />
-    </form>
-  );
+  renderWithJupyterForm(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });

--- a/src/ImageBuilder.test.tsx
+++ b/src/ImageBuilder.test.tsx
@@ -172,16 +172,16 @@ test("invalid org/repo string (not matching pattern)", async () => {
   await user.click(document.body);
 
   expect(
-    screen.getByText(
+    screen.getAllByText(
       "Provide the repository as the format 'organization/repository'.",
-    ),
-  );
+    ).length,
+  ).toBeGreaterThan(0);
 });
 
 test("repofield trims leading/trailing spaces", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(<form><ProfileForm /></form>);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -195,7 +195,7 @@ test("repofield trims leading/trailing spaces", async () => {
   const repoField = screen.getByLabelText("Repository");
   await user.type(repoField, "     extra/spaces  ");
   await user.click(document.body);
-  await user.click(screen.getByRole("button", { name: "Build image" }));
+  await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
 
   expect(repoField).toHaveValue("extra/spaces");
 });
@@ -203,7 +203,7 @@ test("repofield trims leading/trailing spaces", async () => {
 test("ref trims leading/trailing spaces", async () => {
   const user = userEvent.setup();
 
-  renderWithContext(<ProfileForm />);
+  renderWithContext(<form><ProfileForm /></form>);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -218,7 +218,7 @@ test("ref trims leading/trailing spaces", async () => {
   await user.clear(refField);
   await user.type(refField, " branch ");
   await user.click(document.body);
-  await user.click(screen.getByRole("button", { name: "Build image" }));
+  await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
 
   expect(refField).toHaveValue("branch");
 });
@@ -246,10 +246,10 @@ test("invalid org/repo string (wrong base URL)", async () => {
   await user.click(document.body);
 
   expect(
-    screen.getByText(
+    screen.getAllByText(
       "Provide the repository as the format 'organization/repository'.",
-    ),
-  );
+    ).length,
+  ).toBeGreaterThan(0);
 });
 
 test("no org/repo provided", async () => {
@@ -272,10 +272,10 @@ test("no org/repo provided", async () => {
   await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
 
   expect(
-    screen.getByText(
+    screen.getAllByText(
       "Provide the repository as the format 'organization/repository'.",
-    ),
-  );
+    ).length,
+  ).toBeGreaterThan(0);
 });
 
 test("no branch selected", async () => {
@@ -303,5 +303,5 @@ test("no branch selected", async () => {
   await user.clear(screen.queryByLabelText("Git Ref"));
   await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
 
-  expect(screen.getByText("Enter a git ref."));
+  expect(screen.getAllByText("Enter a git ref.").length).toBeGreaterThan(0);
 });

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -135,16 +135,15 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const [fitAddon, setFitAddon] = useState<FitAddon>(null);
 
   const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
-  //const [shouldAutoSubmit, setShouldAutoSubmit] = useState(false);
 
   const hrefReop = useRef<string>(repo);
   const hrefRef = useRef<string>(ref);
   const hrefRepoId = useRef<string>(repoId);
   const hrefTerm = useRef<Terminal>(term);
   const hrefFitAddon = useRef<FitAddon>(fitAddon);
-  const hrefSetIsBuildingImage = useRef<Dispatch<SetStateAction<boolean>>>(setIsBuildingImage);
-  const hrefSetCustomImage = useRef<Dispatch<SetStateAction<string>>>(setCustomImage);
-  const hrefSetCustomImageError = useRef<Dispatch<SetStateAction<string>>>(setCustomImageError);
+  const hrefSetCustomImage = useRef<Dispatch<SetStateAction<string>>>(null);
+  const hrefSetCustomImageError = useRef<Dispatch<SetStateAction<string>>>(null);
+  const hrefSetIsBuildingImage = useRef<Dispatch<SetStateAction<boolean>>>(null);
 
   useEffect(() => {
     hrefReop.current = repo;
@@ -152,8 +151,8 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     hrefRepoId.current = repoId;
     hrefTerm.current = term;
     hrefFitAddon.current = fitAddon;
-    hrefSetIsBuildingImage.current = setIsBuildingImage;
     hrefSetCustomImage.current = setCustomImage;
+    hrefSetIsBuildingImage.current = setIsBuildingImage;
 
   }, [repo, ref, repoId, term, fitAddon, setIsBuildingImage, setCustomImage]);
   

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useContext, useMemo, KeyboardEventHandler,
   Dispatch, SetStateAction,
- } from "react";
+} from "react";
 import { type Terminal } from "xterm";
 import { type FitAddon } from "xterm-addon-fit";
 
@@ -122,19 +122,20 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption,
-          setBuildImageStart } = useFormCache();
+    setBuildImageStart } = useFormCache();
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const repoFieldRef = useRef<HTMLInputElement>();
   const branchFieldRef = useRef<HTMLInputElement>();
 
   const [customImage, setCustomImage] = useState<string>("");
-  const [customImageError, setCustomImageError] = useState<string>(null);
+  const [customImageError] = useState<string>(null);
 
   const [term, setTerm] = useState<Terminal>(null);
   const [fitAddon, setFitAddon] = useState<FitAddon>(null);
 
-  const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
 
   const hrefReop = useRef<string>(repo);
   const hrefRef = useRef<string>(ref);
@@ -170,7 +171,6 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   }
 
   const handleBuildStart = async () => {
-    
     if (repoFieldRef.current && !hrefReop.current) {
       repoFieldRef.current.focus();
       repoFieldRef.current.blur();
@@ -186,7 +186,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     try {
       hrefSetIsBuildingImage.current(true);
       const imageName = await buildImage(hrefRepoId.current, hrefRef.current, 
-                                        hrefTerm.current, hrefFitAddon.current);
+        hrefTerm.current, hrefFitAddon.current);
       //console.log("handleBuildStart: step 4", imageName);
       hrefSetCustomImage.current(imageName);
       hrefTerm.current.write("\nImage has been built! Starting your server...");
@@ -200,11 +200,11 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   };
 
   useEffect(() => {
-     setBuildImageStart(() => handleBuildStart);
-     return () => {
-       setBuildImageStart(null);
-     };
-   }, []);
+    setBuildImageStart(() => handleBuildStart);
+    return () => {
+      setBuildImageStart(null);
+    };
+  }, []);
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === "Enter") {

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -167,11 +167,11 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     setIsBuildingImage(true);
     buildImage(repoId, ref, term, fitAddon)
       .then((imageName) => {
-        setCustomImage(imageName); // This triggers the input field update
-        setShouldAutoSubmit(true); // Signal to auto-submit
+        setCustomImage(imageName);
+        setShouldAutoSubmit(true);
         term.write("\nImage has been built! Starting your server...");
       })
-      .catch(() => console.log("Error building image."))
+      .catch((e) => console.log("Error building image: ", (e as Error).message))
       .finally(() => setIsBuildingImage(false));
   };
 
@@ -184,6 +184,13 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
       setShouldAutoSubmit(false);
     }
   }, [customImage, shouldAutoSubmit]);
+
+  useEffect(() => {
+    if (isActive && permalinkValues["autoStart"] === "true" && !isBuildingImage) {
+      console.log('autoStart detected, triggering build...');
+      handleBuildStart();
+    }
+  }, [isActive, permalinkValues, isBuildingImage]);
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === "Enter") {

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -154,19 +154,15 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     hrefFitAddon.current = fitAddon;
     hrefSetIsBuildingImage.current = setIsBuildingImage;
     hrefSetCustomImage.current = setCustomImage;
-    hrefSetCustomImageError.current = setCustomImageError;
 
-  }, [repo, ref, repoId, term, fitAddon, setIsBuildingImage, setCustomImage, setCustomImageError]);
+  }, [repo, ref, repoId, term, fitAddon, setIsBuildingImage, setCustomImage]);
   
   const repositoryOptions = getRepositoryOptions(name);
   const refOptions = useMemo(() => {
     return getRefOptions(name, repoId);
   }, [repoId]);
 
-  useEffect(() => {
-    if (!isActive) setCustomImageError("");
-  }, [isActive]);
-  
+
 
   if (isActive) {
     setPermalinkValue(`${optionKey}:binderProvider`, "gh");
@@ -276,8 +272,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
         required={isActive}
         aria-hidden="true"
         style={{ display: "none" }}
-        onInvalid={() =>
-          setCustomImageError("Wait for the image build to complete.")}
+        onInvalid={() => {}}
         onChange={() => {}} // Hack to prevent a console error, while at the same time allowing for this field to be validatable, ie. not making it read-only
       />
       <div className="profile-option-container">

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useState, useRef, useContext, useMemo, KeyboardEventHandler,
-  Dispatch, SetStateAction,
-} from "react";
+import { useEffect, useState, useRef, useContext, useMemo, KeyboardEventHandler } from "react";
 import { type Terminal } from "xterm";
 import { type FitAddon } from "xterm-addon-fit";
 
@@ -89,14 +87,12 @@ async function buildImage(
       term.write(data.message);
       // Resize our terminal to make sure it fits messages appropriately
       fitAddon.fit();
-    } else {
-      console.log(data);
     }
 
     switch (data.phase) {
       case "failed": {
         image.close();
-        return Promise.reject();
+        return Promise.reject(new Error("image build failed"));
       }
       case "ready": {
         // Close the EventStream when the image has been built
@@ -116,9 +112,10 @@ interface IImageLogs {
   setTerm: React.Dispatch<React.SetStateAction<Terminal>>;
   setFitAddon: React.Dispatch<React.SetStateAction<FitAddon>>;
   name: string;
+  onSetupError: (error: Error) => void;
 }
 
-function ImageLogs({ setTerm, setFitAddon, name }: IImageLogs) {
+function ImageLogs({ setTerm, setFitAddon, name, onSetupError }: IImageLogs) {
   const terminalId = `${name}--terminal`;
   useEffect(() => {
     async function setup() {
@@ -151,7 +148,14 @@ function ImageLogs({ setTerm, setFitAddon, name }: IImageLogs) {
       setFitAddon(fitAddon);
       term.write("Logs will appear here when image is being built");
     }
-    setup();
+    let cancelled = false;
+    setup().catch((e) => {
+      if (!cancelled) {
+        console.error("ImageLogs setup failed:", e);
+        onSetupError(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    return () => { cancelled = true; };
   }, []);
 
   return (
@@ -169,44 +173,23 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption,
-    setBuildImageStart, isBuildingImage, setIsBuildingImage } = useFormCache();
+    setBuildImageStart, isBuildingImage, setIsBuildingImage,
+    setIsDynamicBuildActive } = useFormCache();
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const repoFieldRef = useRef<HTMLInputElement>();
   const branchFieldRef = useRef<HTMLInputElement>();
 
   const [customImage, setCustomImage] = useState<string>("");
-  const [customImageError] = useState<string>(null);
+  const [customImageError, setCustomImageError] = useState<string>("");
 
   const [term, setTerm] = useState<Terminal>(null);
   const [fitAddon, setFitAddon] = useState<FitAddon>(null);
 
-  const hrefReop = useRef<string>(repo);
-  const hrefRef = useRef<string>(ref);
-  const hrefRepoId = useRef<string>(repoId);
-  const hrefTerm = useRef<Terminal>(term);
-  const hrefFitAddon = useRef<FitAddon>(fitAddon);
-  const hrefSetCustomImage = useRef<Dispatch<SetStateAction<string>>>(null);
-  const hrefSetCustomImageError = useRef<Dispatch<SetStateAction<string>>>(null);
-  const hrefSetIsBuildingImage = useRef<Dispatch<SetStateAction<boolean>>>(null);
-
-  useEffect(() => {
-    hrefReop.current = repo;
-    hrefRef.current = ref;
-    hrefRepoId.current = repoId;
-    hrefTerm.current = term;
-    hrefFitAddon.current = fitAddon;
-    hrefSetCustomImage.current = setCustomImage;
-    hrefSetIsBuildingImage.current = setIsBuildingImage;
-
-  }, [repo, ref, repoId, term, fitAddon, setIsBuildingImage, setCustomImage]);
-  
   const repositoryOptions = getRepositoryOptions(name);
   const refOptions = useMemo(() => {
     return getRefOptions(name, repoId);
   }, [repoId]);
-
-
 
   if (isActive) {
     setPermalinkValue(`${optionKey}:binderProvider`, "gh");
@@ -214,51 +197,70 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     setPermalinkValue(`${optionKey}:ref`, ref);
   }
 
+  useEffect(() => {
+    if (!isActive) setCustomImageError("");
+  }, [isActive]);
+
   const handleBuildStart = async () => {
-    if (repoFieldRef.current && !hrefReop.current) {
+    if (repoFieldRef.current && !repo) {
       repoFieldRef.current.focus();
       repoFieldRef.current.blur();
-      return;
+      throw new Error("Repository is required.");
     }
 
-    if (branchFieldRef.current && !hrefRef.current) {
+    if (branchFieldRef.current && !ref) {
       branchFieldRef.current.focus();
       branchFieldRef.current.blur();
-      return;
+      throw new Error("Git ref is required.");
     }
-
+    console.log(repo);
+    console.log(repoId);
     try {
-      hrefSetIsBuildingImage.current(true);
-      const imageName = await buildImage(hrefRepoId.current, hrefRef.current, 
-        hrefTerm.current, hrefFitAddon.current);
-      //console.log("handleBuildStart: step 4", imageName);
-      hrefSetCustomImage.current(imageName);
-      hrefTerm.current.write("\nImage has been built! Starting your server...");
-      hrefSetCustomImageError.current("");
+      setIsBuildingImage(true);
+      setCustomImageError("");
+      const imageName = await buildImage(repoId!, ref, term, fitAddon);
+      setCustomImage(imageName);
+      term.write("\nImage has been built! Starting your server...");
     } catch (e) {
-      console.log("Error building image: ", (e as Error)?.message || e);
-
+      const message = (e as Error)?.message || "Image build failed.";
+      setCustomImageError(message);
+      throw e;
     } finally {
-      hrefSetIsBuildingImage.current(false);
+      setIsBuildingImage(false);
     }
   };
 
+  // Single ref that always points at the latest handleBuildStart, so the
+  // stable wrapper registered in the context never sees a stale closure.
+  const latestBuildHandler = useRef<() => Promise<void>>();
+  latestBuildHandler.current = handleBuildStart;
+
   useEffect(() => {
-    if (isActive) {
-      setBuildImageStart(() => handleBuildStart);
-    } else {
-      setBuildImageStart(null);
-    }
+    if (!isActive) return;
+    setIsDynamicBuildActive(true);
+    return () => {
+      setIsDynamicBuildActive(false);
+    };
+  }, [isActive, setIsDynamicBuildActive]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    // Creating the wrapper so it can read latestBuildHandler.current when it runs. (preventing stale clusure)
+    const wrapper = () => {
+      const handler = latestBuildHandler.current;
+      return handler ? handler() : Promise.resolve();
+    };
+    setBuildImageStart(() => wrapper);
     return () => {
       setBuildImageStart(null);
     };
-  }, [isActive]);
+  }, [isActive, setBuildImageStart]);
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
       (e.target as HTMLInputElement).blur();
-      handleBuildStart();
+      handleBuildStart().catch(() => {});
     }
   };
 
@@ -314,7 +316,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
         }}
         disabled={isBuildingImage}
       />
-
+      {/* Hidden text input to post the name of  built image  */}
       <input
         type="text"
         name={name}
@@ -323,6 +325,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
         required={isActive}
         aria-hidden="true"
         style={{ display: "none" }}
+        data-dynamic-build="true" 
         onInvalid={() => {}}
         onChange={() => {}} // Hack to prevent a console error, while at the same time allowing for this field to be validatable, ie. not making it read-only
       />
@@ -331,7 +334,12 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
           <b>Build Logs</b>
         </div>
         <div className="profile-option-control-container">
-          <ImageLogs setFitAddon={setFitAddon} setTerm={setTerm} name={name} />
+          <ImageLogs
+            setFitAddon={setFitAddon}
+            setTerm={setTerm}
+            name={name}
+            onSetupError={(e) => setCustomImageError(e.message || "Terminal setup failed.")}
+          />
           {customImageError && (
             <div className="invalid-feedback d-block">
               {customImageError}

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -244,11 +244,15 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   };
 
   useEffect(() => {
-    setBuildImageStart(() => handleBuildStart);
+    if (isActive) {
+      setBuildImageStart(() => handleBuildStart);
+    } else {
+      setBuildImageStart(null);
+    }
     return () => {
       setBuildImageStart(null);
     };
-  }, []);
+  }, [isActive]);
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === "Enter") {

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -169,7 +169,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption,
-    setBuildImageStart } = useFormCache();
+    setBuildImageStart, isBuildingImage, setIsBuildingImage } = useFormCache();
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const repoFieldRef = useRef<HTMLInputElement>();
@@ -180,9 +180,6 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
 
   const [term, setTerm] = useState<Terminal>(null);
   const [fitAddon, setFitAddon] = useState<FitAddon>(null);
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
 
   const hrefReop = useRef<string>(repo);
   const hrefRef = useRef<string>(ref);
@@ -288,6 +285,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
           }
         }
         onKeyDown={handleKeyDown}
+        disabled={isBuildingImage}
       />
       <Combobox
         id={`${name}--ref`}
@@ -310,6 +308,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
         onRemoveOption={(option) => {
           removeRefOption(name, repoFieldProps.value, option);
         }}
+        disabled={isBuildingImage}
       />
 
       <input

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, useContext, useMemo, KeyboardEventHandler } from "react";
+import { flushSync } from "react-dom";
 import { type Terminal } from "xterm";
 import { type FitAddon } from "xterm-addon-fit";
 
@@ -219,7 +220,9 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
       setIsBuildingImage(true);
       setCustomImageError("");
       const imageName = await buildImage(repoId!, ref, term, fitAddon);
-      setCustomImage(imageName);
+      // flushSync forces React to update the hidden input's DOM value synchronously,
+      // so form.requestSubmit() in submitFlow sees the correct value immediately.
+      flushSync(() => { setCustomImage(imageName); });
       term.write("\nImage has been built! Starting your server...");
     } catch (e) {
       const message = (e as Error)?.message || "Image build failed.";

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -8,7 +8,11 @@ import renderWithContext from "./test/renderWithContext";
 
 describe("Profile form", () => {
   test("image and resource fields initially not tabable", async () => {
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
 
     const imageField = screen.getByLabelText("Image");
     expect(imageField.tabIndex).toEqual(-1);
@@ -20,7 +24,11 @@ describe("Profile form", () => {
   test("image and resource fields tabable", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -37,7 +45,11 @@ describe("Profile form", () => {
   test("custom image field is required", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -85,7 +97,11 @@ describe("Profile form", () => {
   test("custom image field needs specific format", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -110,7 +126,11 @@ describe("Profile form", () => {
   test("custom image field accepts specific format", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -136,7 +156,11 @@ describe("Profile form", () => {
   test("Multiple profiles renders", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
 
     const radio = screen.getByRole("radio", {
       name: "GPU Nvidia Tesla T4 GPU",
@@ -168,14 +192,22 @@ describe("Profile form", () => {
   });
 
   test("select with no options should not render", () => {
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
     expect(
       screen.queryByLabelText("Image - No options"),
     ).not.toBeInTheDocument();
   });
 
   test("profile marked as default is selected by default", () => {
-    const { container } = renderWithContext(<ProfileForm />);
+    const { container } = renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -191,7 +223,11 @@ describe("Profile form", () => {
   test("having dynamic_image_building enabled and no other choices shows dropdown", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
     const select = screen.getByLabelText("Image - dynamic image building");
     await user.click(select);
     expect(screen.getByText("Build your own image")).toBeInTheDocument();
@@ -201,7 +237,11 @@ describe("Profile form", () => {
   test("copy permalink to clipboard", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
     const radio = screen.getByRole("radio", {
       name: "GPU Nvidia Tesla T4 GPU",
     });
@@ -210,7 +250,7 @@ describe("Profile form", () => {
 
     const clipboardText = await navigator.clipboard.readText();
 
-    expect(clipboardText).toBe("http://localhost/hub/login?next=/hub/spawn%23fancy-forms-config=%7B%22profile%22%3A%22gpu%22%2C%22image%22%3A%22geospatial%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22resources%22%3A%22mem_2_7%22%2C%22resources%3Aunlisted_choice%22%3A%22%22%7D");
+    expect(clipboardText).toBe("http://localhost/hub/login?next=/hub/spawn%23fancy-forms-config=%7B%22profile%22%3A%22gpu%22%2C%22image%22%3A%22geospatial%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22resources%22%3A%22mem_2_7%22%2C%22resources%3Aunlisted_choice%22%3A%22%22%2C%22autoStart%22%3A%22false%22%7D");
   });
 });
 
@@ -228,7 +268,11 @@ describe("Profile form with URL Params", () => {
 
   test("ignores irrelevant params", () => {
     setHash("#foo=bar");
-    const { container } = renderWithContext(<ProfileForm />);
+    const { container } = renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -240,7 +284,11 @@ describe("Profile form with URL Params", () => {
 
   test("ignores empty config", () => {
     setHash("#fancy-forms-config");
-    const { container } = renderWithContext(<ProfileForm />);
+    const { container } = renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -252,7 +300,11 @@ describe("Profile form with URL Params", () => {
 
   test("shows error for malformed config", () => {
     setHash("#fancy-forms-config=%7B%22profile%22%3A%22build-custom-environment%22%2C%22image%22%3A%22--extra-selectable-item%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22image%3AbinderProvider%22%3A%22gh%22%2C%22image%3AbinderRepo%22%3A%22org%2Fre");
-    const { container } = renderWithContext(<ProfileForm />);
+    const { container } = renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -264,7 +316,11 @@ describe("Profile form with URL Params", () => {
 
   test("preselects values", async () => {
     setHash("#fancy-forms-config=%7B%22profile%22%3A%22build-custom-environment%22%2C%22image%22%3A%22--extra-selectable-item%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22image%3AbinderProvider%22%3A%22gh%22%2C%22image%3AbinderRepo%22%3A%22org%2Frepo%22%2C%22image%3Aref%22%3A%22v1.0%22%7D");
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
 
     const radio = screen.getByRole("radio", {
       name: "Build custom environment Dynamic Image building + unlisted choice",
@@ -281,7 +337,11 @@ describe("Profile form with URL Params", () => {
 
   test("no-option profiles are rendered", () => {
     setHash("#fancy-forms-config=%7B%22profile%22%3A%22build-custom-environment%22%2C%22image%22%3A%22--extra-selectable-item%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22image%3AbinderProvider%22%3A%22gh%22%2C%22image%3AbinderRepo%22%3A%22org%2Frepo%22%2C%22image%3Aref%22%3A%22v1.0%22%7D");
-    renderWithContext(<ProfileForm />);
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
+    );
 
     const empty = screen.queryByRole("radio", {
       name: "Empty Options Profile with empty options",

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -3,13 +3,11 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ProfileForm from "./ProfileForm";
-import renderWithContext from "./test/renderWithContext";
+import renderWithContext, { renderWithJupyterForm } from "./test/renderWithContext";
 
 describe("Profile form", () => {
   test("image and resource fields initially not tabable", async () => {
-    renderWithContext(
-      <ProfileForm />
-    );
+    renderWithContext(<ProfileForm />);
 
     const imageField = screen.getByLabelText("Image");
     expect(imageField.tabIndex).toEqual(-1);
@@ -21,9 +19,7 @@ describe("Profile form", () => {
   test("image and resource fields tabable", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(
-      <ProfileForm />
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -40,9 +36,7 @@ describe("Profile form", () => {
   test("custom image field is required", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(
-      <ProfileForm />
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -63,9 +57,7 @@ describe("Profile form", () => {
   test("shows error summary", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(
-      <form><ProfileForm /></form>
-    );
+    renderWithJupyterForm(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -88,11 +80,7 @@ describe("Profile form", () => {
   test("custom image field needs specific format", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -117,11 +105,7 @@ describe("Profile form", () => {
   test("custom image field accepts specific format", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -182,11 +166,7 @@ describe("Profile form", () => {
   test("Multiple profiles renders", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "GPU Nvidia Tesla T4 GPU",
@@ -218,22 +198,14 @@ describe("Profile form", () => {
   });
 
   test("select with no options should not render", () => {
-    renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    renderWithContext(<ProfileForm />);
     expect(
       screen.queryByLabelText("Image - No options"),
     ).not.toBeInTheDocument();
   });
 
   test("profile marked as default is selected by default", () => {
-    const { container } = renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    const { container } = renderWithContext(<ProfileForm />);
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -249,11 +221,7 @@ describe("Profile form", () => {
   test("having dynamic_image_building enabled and no other choices shows dropdown", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    renderWithContext(<ProfileForm />);
     const select = screen.getByLabelText("Image - dynamic image building");
     await user.click(select);
     expect(screen.getByText("Build your own image")).toBeInTheDocument();
@@ -263,11 +231,7 @@ describe("Profile form", () => {
   test("copy permalink to clipboard", async () => {
     const user = userEvent.setup();
 
-    renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    renderWithContext(<ProfileForm />);
     const radio = screen.getByRole("radio", {
       name: "GPU Nvidia Tesla T4 GPU",
     });
@@ -294,11 +258,7 @@ describe("Profile form with URL Params", () => {
 
   test("ignores irrelevant params", () => {
     setHash("#foo=bar");
-    const { container } = renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    const { container } = renderWithContext(<ProfileForm />);
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -310,11 +270,7 @@ describe("Profile form with URL Params", () => {
 
   test("ignores empty config", () => {
     setHash("#fancy-forms-config");
-    const { container } = renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    const { container } = renderWithContext(<ProfileForm />);
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -326,11 +282,7 @@ describe("Profile form with URL Params", () => {
 
   test("shows error for malformed config", () => {
     setHash("#fancy-forms-config=%7B%22profile%22%3A%22build-custom-environment%22%2C%22image%22%3A%22--extra-selectable-item%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22image%3AbinderProvider%22%3A%22gh%22%2C%22image%3AbinderRepo%22%3A%22org%2Fre");
-    const { container } = renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    const { container } = renderWithContext(<ProfileForm />);
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -342,11 +294,7 @@ describe("Profile form with URL Params", () => {
 
   test("preselects values", async () => {
     setHash("#fancy-forms-config=%7B%22profile%22%3A%22build-custom-environment%22%2C%22image%22%3A%22--extra-selectable-item%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22image%3AbinderProvider%22%3A%22gh%22%2C%22image%3AbinderRepo%22%3A%22org%2Frepo%22%2C%22image%3Aref%22%3A%22v1.0%22%7D");
-    renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "Build custom environment Dynamic Image building + unlisted choice",
@@ -363,11 +311,7 @@ describe("Profile form with URL Params", () => {
 
   test("no-option profiles are rendered", () => {
     setHash("#fancy-forms-config=%7B%22profile%22%3A%22build-custom-environment%22%2C%22image%22%3A%22--extra-selectable-item%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22image%3AbinderProvider%22%3A%22gh%22%2C%22image%3AbinderRepo%22%3A%22org%2Frepo%22%2C%22image%3Aref%22%3A%22v1.0%22%7D");
-    renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
-    );
+    renderWithContext(<ProfileForm />);
 
     const empty = screen.queryByRole("radio", {
       name: "Empty Options Profile with empty options",

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -8,9 +8,7 @@ import renderWithContext from "./test/renderWithContext";
 describe("Profile form", () => {
   test("image and resource fields initially not tabable", async () => {
     renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
+      <ProfileForm />
     );
 
     const imageField = screen.getByLabelText("Image");
@@ -24,9 +22,7 @@ describe("Profile form", () => {
     const user = userEvent.setup();
 
     renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
+      <ProfileForm />
     );
 
     const radio = screen.getByRole("radio", {
@@ -45,9 +41,7 @@ describe("Profile form", () => {
     const user = userEvent.setup();
 
     renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
+      <ProfileForm />
     );
 
     const radio = screen.getByRole("radio", {
@@ -70,9 +64,7 @@ describe("Profile form", () => {
     const user = userEvent.setup();
 
     renderWithContext(
-      <form>
-        <ProfileForm />
-      </form>
+      <form><ProfileForm /></form>
     );
 
     const radio = screen.getByRole("radio", {
@@ -86,7 +78,7 @@ describe("Profile form", () => {
 
     const submitButton = screen.getByRole("button", { "name": "Start" });
     await user.click(submitButton);
-    await waitFor(() => expect(screen.getByText("Unable to start the server. The form is incomplete.")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Unable to start the server. Check the error below.")).toBeInTheDocument());
     expect(screen.queryAllByText("Enter a value.").length).toEqual(2);
 
     // Check that one of the errors is the link in the error summary.

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -131,10 +131,15 @@ function Form() {
 
   useEffect(() => {
     // Only auto-submit for non-build profiles
-    if (permalinkValues["autoStart"] === "true" && permalinkValues["image"] !== "--extra-selectable-item") {
+    if (permalinkValues["autoStart"] === "true") {
       const form = document.querySelector("form");
       if (form) {
-        form.requestSubmit();
+        const button = form.querySelector('button[type="submit"]') as HTMLButtonElement | null;
+        if (button) {
+          setTimeout(() => {
+            button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+          }, 1000); // Give the form a second to render, and the profile to be selected, HACK but it works
+        }
       }
     }
   }, [permalinkValues]);

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -33,18 +33,18 @@ function Form() {
   const [formErrors, setFormErrors] = useState<Element[]>([]);
   const { cacheChoiceOption, cacheRepositorySelection, buildImageStart } = useFormCache();
 
-  const [eventForSubmit, setEventForSubmit] = useState<MouseEvent<HTMLButtonElement>|null>(null);
+  const [shouldSubmit, setShouldSubmit] = useState(false);
 
   useEffect(() => {
-    if (eventForSubmit) {
-      submitTheForm(eventForSubmit);
-      setEventForSubmit(null);
+    if (shouldSubmit) {
+      submitTheForm();
+      setShouldSubmit(false);
       const form = document.querySelector("form");
       if (form) {
         form.requestSubmit();
       }
     }
-  }, [eventForSubmit]);
+  }, [shouldSubmit]);
 
 
   const handleSubmit: MouseEventHandler<HTMLButtonElement> =  async (e: MouseEvent<HTMLButtonElement>) => {
@@ -53,17 +53,20 @@ function Form() {
     if (buildImageStart){
       await buildImageStart();
     }
-    setEventForSubmit(e);
+    setShouldSubmit(true);
   }
 
-  const submitTheForm =  (e: MouseEvent<HTMLButtonElement>) => {
+
+  const submitTheForm =  () => {
 
     setProfileError("");
     setFormErrors([]);
-    const form = (e.target as HTMLElement).closest("form");
 
-    // validate the form
+    const form = document.querySelector("form");
+
+
     const formIsValid = form.checkValidity();
+
 
     // prevent form submit
     if (!formIsValid) {
@@ -79,7 +82,6 @@ function Form() {
       }, 100);
 
       setProfileError(!selectedProfile ? "Select a container profile" : "");
-      e.preventDefault();
       return;
     }
 
@@ -130,7 +132,6 @@ function Form() {
   }, [permalinkValues.profile]);
 
   useEffect(() => {
-    // Only auto-submit for non-build profiles
     if (permalinkValues["autoStart"] === "true") {
       const form = document.querySelector("form");
       if (form) {

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -1,4 +1,5 @@
 import {
+  MouseEvent,
   ChangeEventHandler,
   MouseEventHandler,
   useContext,
@@ -30,9 +31,33 @@ function Form() {
   const { permalinkValues, setPermalinkValue, permalinkParseError } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
   const [formErrors, setFormErrors] = useState<Element[]>([]);
-  const { cacheChoiceOption, cacheRepositorySelection } = useFormCache();
+  const { cacheChoiceOption, cacheRepositorySelection, buildImageStart } = useFormCache();
 
-  const handleSubmit: MouseEventHandler<HTMLButtonElement> = (e) => {
+  const [eventForSubmit, setEventForSubmit] = useState<MouseEvent<HTMLButtonElement>|null>(null);
+
+  useEffect(() => {
+    if (eventForSubmit) {
+      submitTheForm(eventForSubmit);
+      setEventForSubmit(null);
+      const form = document.querySelector("form");
+      if (form) {
+        form.requestSubmit();
+      }
+    }
+  }, [eventForSubmit]);
+
+
+  const handleSubmit: MouseEventHandler<HTMLButtonElement> =  async (e: MouseEvent<HTMLButtonElement>) => {
+
+    e.preventDefault();
+    if (buildImageStart){
+      await buildImageStart();
+    }
+    setEventForSubmit(e);
+  }
+
+  const submitTheForm =  (e: MouseEvent<HTMLButtonElement>) => {
+
     setProfileError("");
     setFormErrors([]);
     const form = (e.target as HTMLElement).closest("form");
@@ -206,7 +231,7 @@ function Form() {
         type="submit"
         onClick={handleSubmit}
       >
-        Start
+        { buildImageStart ? "Build Image and Start" : "Start" }
       </button>
     </fieldset>
   );

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -54,7 +54,7 @@ function Form() {
       await buildImageStart();
     }
     setShouldSubmit(true);
-  }
+  };
 
 
   const submitTheForm =  () => {
@@ -135,10 +135,10 @@ function Form() {
     if (permalinkValues["autoStart"] === "true") {
       const form = document.querySelector("form");
       if (form) {
-        const button = form.querySelector('button[type="submit"]') as HTMLButtonElement | null;
+        const button = form.querySelector("button[type=\"submit\"]") as HTMLButtonElement | null;
         if (button) {
           setTimeout(() => {
-            button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+            button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
           }, 1000); // Give the form a second to render, and the profile to be selected, HACK but it works
         }
       }

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -104,6 +104,18 @@ function Form() {
     }
   }, [permalinkValues.profile]);
 
+  useEffect(() => {
+    // Only auto-submit for non-build profiles
+    if (permalinkValues["autoStart"] === "true" && permalinkValues["image"] !== "--extra-selectable-item") {
+      const form = document.querySelector("form");
+      if (form) {
+        form.requestSubmit();
+      }
+    }
+  }, [permalinkValues]);
+
+  
+
   return (
     <fieldset
       aria-label="Select profile"

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -51,7 +51,10 @@ function Form() {
 
     e.preventDefault();
     if (buildImageStart){
-      await buildImageStart();
+      const form = document.querySelector("form");
+      if (form) {
+        form.requestSubmit()
+      }
     }
     setShouldSubmit(true);
   };
@@ -135,12 +138,10 @@ function Form() {
     if (permalinkValues["autoStart"] === "true") {
       const form = document.querySelector("form");
       if (form) {
-        const button = form.querySelector("button[type=\"submit\"]") as HTMLButtonElement | null;
-        if (button) {
-          setTimeout(() => {
-            button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-          }, 1000); // Give the form a second to render, and the profile to be selected, HACK but it works
-        }
+        setTimeout(() => {
+          form.requestSubmit()
+        }, 500); // Give the form a second to render, and the profile to be selected, HACK but it works
+      
       }
     }
   }, [permalinkValues]);
@@ -215,8 +216,8 @@ function Form() {
           <p><b>Unable to start the server. The form is incomplete.</b></p>
           <ul>
             {profileError && <li>{profileError}</li>}
-            {formErrors.map(err => (
-              <li>
+            {formErrors.map((err, index) => (
+              <li key={index}>
                 <a
                   href="#"
                   onClick={(e) => {

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -1,5 +1,4 @@
 import {
-  MouseEvent,
   ChangeEventHandler,
   MouseEventHandler,
   useContext,
@@ -31,62 +30,26 @@ function Form() {
   const { permalinkValues, setPermalinkValue, permalinkParseError } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
   const [formErrors, setFormErrors] = useState<Element[]>([]);
-  const { cacheChoiceOption, cacheRepositorySelection, buildImageStart, isBuildingImage } = useFormCache();
-
-  const [shouldSubmit, setShouldSubmit] = useState(false);
-
-  useEffect(() => {
-    if (shouldSubmit) {
-      cacheFormValues();
-      setShouldSubmit(false);
-      const form = document.querySelector("form");
-      if (form) {
-        form.requestSubmit();
-      }
-    }
-  }, [shouldSubmit]);
+  const {
+    cacheChoiceOption,
+    cacheRepositorySelection,
+    buildImageStart,
+    isBuildingImage,
+    isDynamicBuildActive,
+  } = useFormCache();
 
 
-  const handleSubmit: MouseEventHandler<HTMLButtonElement> = async (e: MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    setProfileError("");
-    setFormErrors([]);
-
-    const form = document.querySelector("form");
-    if (!form) {
-      return;
-    }
-
-    let formIsValid = true;
-    let firstInvalidField: HTMLInputElement | null = null;
-
-    form.querySelectorAll<HTMLInputElement>('input, select, textarea').forEach((field) => {
-      if (field.offsetParent !== null && !field.disabled && !field.checkValidity()) {
-        formIsValid = false;
-        if (!firstInvalidField) {
-          firstInvalidField = field;
-        }
-      }
-    });
-
-    if (!formIsValid) {
-      if (firstInvalidField) {
-        firstInvalidField.reportValidity();
-      }
-      setProfileError(!selectedProfile ? "Select a container profile" : "");
-      return;
-    }
-
-    if (buildImageStart) {
-      await buildImageStart();
-    }
-    setShouldSubmit(true);
+  const collectFormErrors = (form: HTMLFormElement) => {
+    setTimeout(() => {
+      const errors = form.getElementsByClassName("invalid-feedback");
+      setFormErrors(Array.from(errors));
+    }, 10);
+    setTimeout(() => {
+      window.scrollTo(0, document.body.scrollHeight);
+    }, 100);
   };
 
-
-  const cacheFormValues = () => {
-    const form = document.querySelector("form");
-
+  const cacheFormValues = (form: HTMLFormElement) => {
     const cacheUnlistedChoices = form.getElementsByClassName("cache-unlisted-choice");
     Array.from(cacheUnlistedChoices).forEach((el) => {
       const { id, value } = el as HTMLInputElement;
@@ -98,10 +61,86 @@ function Form() {
       const { id, value } = el as HTMLInputElement;
       if (id.endsWith("--repo")) {
         const fieldName = id.slice(0, -6);
-        const refField = document.getElementById(`${fieldName}--ref`);
-        cacheRepositorySelection(fieldName, value, (refField as HTMLInputElement).value);
+        const refField = form.querySelector(`#${CSS.escape(`${fieldName}--ref`)}`);
+        if (refField) {
+          cacheRepositorySelection(fieldName, value, (refField as HTMLInputElement).value);
+        }
       }
     });
+  };
+
+  const preBuildValidate = (form: HTMLFormElement): boolean => {
+    let firstInvalid: HTMLInputElement | null = null;
+    form.querySelectorAll<HTMLInputElement>("input, select, textarea").forEach((field) => {
+      // Hidden text input for dynamically buit image name (input is empty)
+      if (field.dataset.dynamicBuild === "true") return;
+      if (field.disabled) return;
+      if (!field.checkValidity()) {
+        if (!firstInvalid) firstInvalid = field;
+      }
+    });
+    if (firstInvalid) {
+      firstInvalid!.reportValidity();
+      return false;
+    }
+    return true;
+  };
+
+  const submitFlow = async (
+    form: HTMLFormElement | null,
+    nativeEvent?: { preventDefault: () => void },
+  ): Promise<boolean> => {
+    setProfileError("");
+    setFormErrors([]);
+    // When there is no selected profile
+    if (!selectedProfile) {
+      nativeEvent?.preventDefault();
+      setProfileError("Select a container profile");
+      return false;
+    }
+    // when dynamic image build is requested
+    if (isDynamicBuildActive && buildImageStart) {
+      if (!form) return false;
+      nativeEvent?.preventDefault();
+      // but there is an error in form
+      if (!preBuildValidate(form)) {
+        collectFormErrors(form);
+        return false;
+      }
+
+      try {
+        await buildImageStart();
+      } catch {
+        collectFormErrors(form);
+        return false;
+      }
+
+      cacheFormValues(form);
+      form.requestSubmit();
+      return true;
+    }
+
+    if (form && !form.checkValidity()) {
+      nativeEvent?.preventDefault();
+      collectFormErrors(form);
+      return false;
+    }
+
+    if (form) {
+      cacheFormValues(form);
+    }
+
+    if (!nativeEvent) {
+      form?.requestSubmit();
+    }
+    return true;
+  };
+
+  const handleSubmit: MouseEventHandler<HTMLButtonElement> = (e) => {
+    const button = e.currentTarget;
+    const form = button.closest("form");
+
+    void submitFlow(form, e);
   };
 
   const handleProfileSelect: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -131,6 +170,8 @@ function Form() {
     }
   }, [permalinkValues.profile]);
 
+  // @TODO: Replace setTimeout (hack for racing condition) + dispatchEvent (hack for stale closure)
+  // to proper sequencing of the events and calling submitflow directly
   useEffect(() => {
     if (permalinkValues["autoStart"] === "true") {
       const form = document.querySelector("form");
@@ -144,8 +185,6 @@ function Form() {
       }
     }
   }, [permalinkValues]);
-
-
 
   return (
     <fieldset
@@ -169,7 +208,7 @@ function Form() {
             id={`profile-${slug}`}
             key={slug}
             className={`profile-select ${selectedProfile?.slug === slug ? "selected-profile" : ""
-              }`}
+            }`}
             onClick={() => {
               setProfile(slug);
               setPermalinkValue("profile", slug);
@@ -211,7 +250,7 @@ function Form() {
         <div
           className={`form-errors ${formErrors.length > 0 || profileError ? "d-block" : "d-none"}`}
         >
-          <p><b>Unable to start the server. The form is incomplete.</b></p>
+          <p><b>Unable to start the server. Check the error below.</b></p>
           <ul>
             {profileError && <li>{profileError}</li>}
             {formErrors.map((err, index) => (
@@ -237,7 +276,7 @@ function Form() {
         onClick={handleSubmit}
         disabled={isBuildingImage}
       >
-        {buildImageStart ? "Build Image and Start" : "Start"}
+        {isDynamicBuildActive ? "Build Image and Start" : "Start"}
       </button>
     </fieldset>
   );

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -254,6 +254,7 @@ function Form() {
           <ul>
             {profileError && <li>{profileError}</li>}
             {formErrors.map((err, index) => (
+              // eslint-disable-next-line react/no-array-index-key
               <li key={index}>
                 <a
                   href="#"

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -37,7 +37,7 @@ function Form() {
 
   useEffect(() => {
     if (shouldSubmit) {
-      submitTheForm();
+      cacheFormValues();
       setShouldSubmit(false);
       const form = document.querySelector("form");
       if (form) {
@@ -48,8 +48,35 @@ function Form() {
 
 
   const handleSubmit: MouseEventHandler<HTMLButtonElement> = async (e: MouseEvent<HTMLButtonElement>) => {
-
     e.preventDefault();
+    setProfileError("");
+    setFormErrors([]);
+
+    const form = document.querySelector("form");
+    if (!form) {
+      return;
+    }
+
+    let formIsValid = true;
+    let firstInvalidField: HTMLInputElement | null = null;
+
+    form.querySelectorAll<HTMLInputElement>('input, select, textarea').forEach((field) => {
+      if (field.offsetParent !== null && !field.disabled && !field.checkValidity()) {
+        formIsValid = false;
+        if (!firstInvalidField) {
+          firstInvalidField = field;
+        }
+      }
+    });
+
+    if (!formIsValid) {
+      if (firstInvalidField) {
+        firstInvalidField.reportValidity();
+      }
+      setProfileError(!selectedProfile ? "Select a container profile" : "");
+      return;
+    }
+
     if (buildImageStart) {
       await buildImageStart();
     }
@@ -57,42 +84,15 @@ function Form() {
   };
 
 
-  const submitTheForm = () => {
-
-    setProfileError("");
-    setFormErrors([]);
-
+  const cacheFormValues = () => {
     const form = document.querySelector("form");
 
-
-    const formIsValid = form.checkValidity();
-
-
-    // prevent form submit
-    if (!formIsValid) {
-      setTimeout(() => {
-        // Timeout here so we can collect the errors after the errors are rendered on the page
-        const errors = form.getElementsByClassName("invalid-feedback");
-        setFormErrors(Array.from(errors));
-      }, 10);
-
-      setTimeout(() => {
-        // Need to wait for the error summary to render
-        window.scrollTo(0, document.body.scrollHeight);
-      }, 100);
-
-      setProfileError(!selectedProfile ? "Select a container profile" : "");
-      return;
-    }
-
-    // Cache active unlisted-choice values
     const cacheUnlistedChoices = form.getElementsByClassName("cache-unlisted-choice");
     Array.from(cacheUnlistedChoices).forEach((el) => {
       const { id, value } = el as HTMLInputElement;
       cacheChoiceOption(id, value);
     });
 
-    // Cache active repository/ref values
     const cacheRepositories = form.getElementsByClassName("cache-repository");
     Array.from(cacheRepositories).forEach((el) => {
       const { id, value } = el as HTMLInputElement;

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -129,7 +129,7 @@ function Form() {
     if (form) {
       cacheFormValues(form);
     }
-
+    // When submit happened by mimicking the button (from query parameter)
     if (!nativeEvent) {
       form?.requestSubmit();
     }

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -47,20 +47,17 @@ function Form() {
   }, [shouldSubmit]);
 
 
-  const handleSubmit: MouseEventHandler<HTMLButtonElement> =  async (e: MouseEvent<HTMLButtonElement>) => {
+  const handleSubmit: MouseEventHandler<HTMLButtonElement> = async (e: MouseEvent<HTMLButtonElement>) => {
 
     e.preventDefault();
-    if (buildImageStart){
-      const form = document.querySelector("form");
-      if (form) {
-        form.requestSubmit()
-      }
+    if (buildImageStart) {
+      await buildImageStart();
     }
     setShouldSubmit(true);
   };
 
 
-  const submitTheForm =  () => {
+  const submitTheForm = () => {
 
     setProfileError("");
     setFormErrors([]);
@@ -138,15 +135,17 @@ function Form() {
     if (permalinkValues["autoStart"] === "true") {
       const form = document.querySelector("form");
       if (form) {
-        setTimeout(() => {
-          form.requestSubmit()
-        }, 500); // Give the form a second to render, and the profile to be selected, HACK but it works
-      
+        const button = form.querySelector("button[type=\"submit\"]") as HTMLButtonElement | null;
+        if (button) {
+          setTimeout(() => {
+            button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+          }, 500); // Give the form a second to render, and the profile to be selected, HACK but it works
+        }
       }
     }
   }, [permalinkValues]);
 
-  
+
 
   return (
     <fieldset
@@ -169,9 +168,8 @@ function Form() {
           <div
             id={`profile-${slug}`}
             key={slug}
-            className={`profile-select ${
-              selectedProfile?.slug === slug ? "selected-profile" : ""
-            }`}
+            className={`profile-select ${selectedProfile?.slug === slug ? "selected-profile" : ""
+              }`}
             onClick={() => {
               setProfile(slug);
               setPermalinkValue("profile", slug);
@@ -238,7 +236,7 @@ function Form() {
         type="submit"
         onClick={handleSubmit}
       >
-        { buildImageStart ? "Build Image and Start" : "Start" }
+        {buildImageStart ? "Build Image and Start" : "Start"}
       </button>
     </fieldset>
   );

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -31,7 +31,7 @@ function Form() {
   const { permalinkValues, setPermalinkValue, permalinkParseError } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
   const [formErrors, setFormErrors] = useState<Element[]>([]);
-  const { cacheChoiceOption, cacheRepositorySelection, buildImageStart } = useFormCache();
+  const { cacheChoiceOption, cacheRepositorySelection, buildImageStart, isBuildingImage } = useFormCache();
 
   const [shouldSubmit, setShouldSubmit] = useState(false);
 
@@ -138,8 +138,9 @@ function Form() {
         const button = form.querySelector("button[type=\"submit\"]") as HTMLButtonElement | null;
         if (button) {
           setTimeout(() => {
-            button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-          }, 500); // Give the form a second to render, and the profile to be selected, HACK but it works
+            button.dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
+            form.requestSubmit()
+          }, 1000); // Give the form a second to render, and the profile to be selected, HACK but it works
         }
       }
     }
@@ -235,6 +236,7 @@ function Form() {
         className="btn btn-jupyter form-control"
         type="submit"
         onClick={handleSubmit}
+        disabled={isBuildingImage}
       >
         {buildImageStart ? "Build Image and Start" : "Start"}
       </button>

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -139,7 +139,6 @@ function Form() {
         if (button) {
           setTimeout(() => {
             button.dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
-            form.requestSubmit()
           }, 1000); // Give the form a second to render, and the profile to be selected, HACK but it works
         }
       }

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -4,6 +4,8 @@ import {
   useCallback,
   useEffect,
   useState,
+  Dispatch,
+  SetStateAction
 } from "react";
 import { cacheOption, getRecords, removeOption, removeRepository } from "../utils/indexedDb";
 
@@ -20,6 +22,9 @@ export interface IFormCache {
     repository: string,
     ref: string,
   ) => void;
+
+  buildImageStart: (() => Promise<void>) | null;
+  setBuildImageStart: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
 }
 
 type TChoiceEntry = {
@@ -153,6 +158,8 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     loadPreviousRepositories();
   }, []);
 
+   const [buildImageStart, setBuildImageStart] = useState<(() => Promise<void>) | null>(null);
+
   const contextValue = {
     getChoiceOptions,
     cacheChoiceOption,
@@ -161,7 +168,9 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     cacheRepositorySelection,
     removeChoiceOption,
     removeRepositoryOption,
-    removeRefOption
+    removeRefOption,
+    buildImageStart,
+    setBuildImageStart
   };
 
   return (

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -158,7 +158,7 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     loadPreviousRepositories();
   }, []);
 
-   const [buildImageStart, setBuildImageStart] = useState<(() => Promise<void>) | null>(null);
+  const [buildImageStart, setBuildImageStart] = useState<(() => Promise<void>) | null>(null);
 
   const contextValue = {
     getChoiceOptions,

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -25,6 +25,8 @@ export interface IFormCache {
 
   buildImageStart: (() => Promise<void>) | null;
   setBuildImageStart: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
+  isBuildingImage: boolean;
+  setIsBuildingImage: Dispatch<SetStateAction<boolean>>;
 }
 
 type TChoiceEntry = {
@@ -159,6 +161,7 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
   }, []);
 
   const [buildImageStart, setBuildImageStart] = useState<(() => Promise<void>) | null>(null);
+  const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
 
   const contextValue = {
     getChoiceOptions,
@@ -170,7 +173,9 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     removeRepositoryOption,
     removeRefOption,
     buildImageStart,
-    setBuildImageStart
+    setBuildImageStart,
+    isBuildingImage,
+    setIsBuildingImage
   };
 
   return (

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -28,6 +28,8 @@ export interface IFormCache {
   setBuildImageStart: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
   isBuildingImage: boolean;
   setIsBuildingImage: Dispatch<SetStateAction<boolean>>;
+  isDynamicBuildActive: boolean;
+  setIsDynamicBuildActive: Dispatch<SetStateAction<boolean>>;
 }
 
 type TChoiceEntry = {
@@ -163,6 +165,7 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
 
   const [buildImageStart, setBuildImageStart] = useState<(() => Promise<void>) | null>(null);
   const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
+  const [isDynamicBuildActive, setIsDynamicBuildActive] = useState<boolean>(false);
 
   const contextValue = useMemo(() => ({
     getChoiceOptions,
@@ -176,7 +179,9 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     buildImageStart,
     setBuildImageStart,
     isBuildingImage,
-    setIsBuildingImage
+    setIsBuildingImage,
+    isDynamicBuildActive,
+    setIsDynamicBuildActive,
   }), [
     getChoiceOptions,
     cacheChoiceOption,
@@ -189,7 +194,9 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     buildImageStart,
     setBuildImageStart,
     isBuildingImage,
-    setIsBuildingImage
+    setIsBuildingImage,
+    isDynamicBuildActive,
+    setIsDynamicBuildActive,
   ]);
 
   return (

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useState,
+  useMemo,
   Dispatch,
   SetStateAction
 } from "react";
@@ -163,7 +164,7 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
   const [buildImageStart, setBuildImageStart] = useState<(() => Promise<void>) | null>(null);
   const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
 
-  const contextValue = {
+  const contextValue = useMemo(() => ({
     getChoiceOptions,
     cacheChoiceOption,
     getRepositoryOptions,
@@ -176,7 +177,20 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     setBuildImageStart,
     isBuildingImage,
     setIsBuildingImage
-  };
+  }), [
+    getChoiceOptions,
+    cacheChoiceOption,
+    getRepositoryOptions,
+    getRefOptions,
+    cacheRepositorySelection,
+    removeChoiceOption,
+    removeRepositoryOption,
+    removeRefOption,
+    buildImageStart,
+    setBuildImageStart,
+    isBuildingImage,
+    setIsBuildingImage
+  ]);
 
   return (
     <FormCacheContext.Provider value={contextValue}>

--- a/src/context/Permalink.tsx
+++ b/src/context/Permalink.tsx
@@ -46,6 +46,7 @@ export const PermalinkProvider = ({ children }: PropsWithChildren) => {
   };
 
   const copyPermalink = () => {
+    setPermalinkValue("autoStart", "false");
     const params = new URLSearchParams();
     params.set(queryParamName, JSON.stringify(urlParams));
     const link = `${location.origin}/hub/login${location.search ? location.search + "&" : "?"}next=/hub/spawn%23${params.toString()}`;

--- a/src/context/Permalink.tsx
+++ b/src/context/Permalink.tsx
@@ -27,6 +27,7 @@ export const PermalinkProvider = ({ children }: PropsWithChildren) => {
       try {
         return JSON.parse(formConfig);
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.error("Error parsing form config", e);
         setPermalinkParseError(true);
       }

--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -11,6 +11,8 @@ function useFormCache(): IFormCache {
     removeChoiceOption,
     removeRepositoryOption,
     removeRefOption,
+    buildImageStart,
+    setBuildImageStart,
   } = useContext(FormCacheContext) as IFormCache;
 
   return useMemo(
@@ -23,6 +25,8 @@ function useFormCache(): IFormCache {
       removeChoiceOption,
       removeRepositoryOption,
       removeRefOption,
+      buildImageStart,
+      setBuildImageStart,
     }),
     [
       getChoiceOptions,
@@ -33,6 +37,8 @@ function useFormCache(): IFormCache {
       removeChoiceOption,
       removeRepositoryOption,
       removeRefOption,
+      buildImageStart,
+      setBuildImageStart,
     ],
   );
 }

--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -13,6 +13,8 @@ function useFormCache(): IFormCache {
     removeRefOption,
     buildImageStart,
     setBuildImageStart,
+    isBuildingImage,
+    setIsBuildingImage,
   } = useContext(FormCacheContext) as IFormCache;
 
   return useMemo(
@@ -27,6 +29,8 @@ function useFormCache(): IFormCache {
       removeRefOption,
       buildImageStart,
       setBuildImageStart,
+      isBuildingImage,
+      setIsBuildingImage,
     }),
     [
       getChoiceOptions,
@@ -39,6 +43,8 @@ function useFormCache(): IFormCache {
       removeRefOption,
       buildImageStart,
       setBuildImageStart,
+      isBuildingImage,
+      setIsBuildingImage,
     ],
   );
 }

--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -15,6 +15,8 @@ function useFormCache(): IFormCache {
     setBuildImageStart,
     isBuildingImage,
     setIsBuildingImage,
+    isDynamicBuildActive,
+    setIsDynamicBuildActive,
   } = useContext(FormCacheContext) as IFormCache;
 
   return useMemo(
@@ -31,6 +33,8 @@ function useFormCache(): IFormCache {
       setBuildImageStart,
       isBuildingImage,
       setIsBuildingImage,
+      isDynamicBuildActive,
+      setIsDynamicBuildActive,
     }),
     [
       getChoiceOptions,
@@ -45,6 +49,8 @@ function useFormCache(): IFormCache {
       setBuildImageStart,
       isBuildingImage,
       setIsBuildingImage,
+      isDynamicBuildActive,
+      setIsDynamicBuildActive,
     ],
   );
 }

--- a/src/test/renderWithContext.tsx
+++ b/src/test/renderWithContext.tsx
@@ -16,4 +16,8 @@ function renderWithContext(children: React.ReactNode) {
   );
 }
 
+export function renderWithJupyterForm(children: React.ReactNode) {
+  return renderWithContext(<form>{children}</form>);
+}
+
 export default renderWithContext;


### PR DESCRIPTION
This PR is based on  https://github.com/2i2c-org/jupyterhub-fancy-profiles/pull/132 by @rtmiz 

a few changes introduced from this PR: 
 - Explicit flag for isDynamicBuildActive (instead of depending on buildImageStart truthiness)
  - Submit flow was rearranged so branching is (hopefully) clearer. This also helped get rid of unnecessary <form> wrappers in tests. At least for now, I think it's better to be explicit about which tests actually need a form, so we know this change didn't introduce any unintended   side effects beyond submit functionality.
  - Errors are now explicitly thrown instead of silently swallowed.

I was hoping to get rid of `setTimeout` hack - but this will require a bigger change that I don't want to introduce now. I am hoping to do a follow-up soon! 