### PR TITLE
Follow up of #149

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "configurable-http-proxy": "^4.6.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.6.0",
         "react-select": "^5.7.4",
         "xterm": "^5.1.0",
         "xterm-addon-fit": "^0.8.0"
@@ -10946,6 +10947,15 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "configurable-http-proxy": "^4.6.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.6.0",
     "react-select": "^5.7.4",
     "xterm": "^5.1.0",
     "xterm-addon-fit": "^0.8.0"

--- a/src/ImageBuilder.test.tsx
+++ b/src/ImageBuilder.test.tsx
@@ -346,7 +346,7 @@ test("build image and start submits form on first click with image name in hidde
   await user.click(screen.getByRole("button", { name: "Build Image and Start" }));
 
   // Build should complete and form should submit in this single click.
-  // If flushSync is missing, the hidden input still has value="" at submit time.
+  // If the hidden input's ref isn't written synchronously before submit, it still has value="" here.
   await waitFor(() => expect(requestSubmitSpy).toHaveBeenCalledTimes(1));
   expect(hiddenValueAtSubmit).toBe("ghcr.io/org/repo:abc123");
 

--- a/src/ImageBuilder.test.tsx
+++ b/src/ImageBuilder.test.tsx
@@ -1,4 +1,4 @@
-import { expect, test } from "@jest/globals";
+import { afterEach, describe, expect, test } from "@jest/globals";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "jest-fetch-mock";
@@ -352,4 +352,68 @@ test("build image and start submits form on first click with image name in hidde
 
   localStorage.removeItem("jupytherhub-build-token");
   requestSubmitSpy.mockRestore();
+});
+
+describe("submit slot", () => {
+  test("'Build Image and Start' button renders in submit-slot when build option is active", async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithJupyterForm(<ProfileForm />);
+
+    await user.click(screen.getByRole("radio", {
+      name: "Build custom environment Dynamic Image building + unlisted choice",
+    }));
+
+    const imageSelect = screen.getByLabelText("Image - dynamic image building");
+    await user.click(imageSelect);
+    await user.click(screen.getByText("Build your own image"));
+
+    expect(screen.queryByRole("button", { name: "Start" })).not.toBeInTheDocument();
+    const buildButton = screen.getByRole("button", { name: "Build Image and Start" });
+    expect(container.querySelector("#submit-slot")).toContainElement(buildButton);
+  });
+});
+
+describe("autoStart", () => {
+  function setHash(hash: string) {
+    const location = { ...window.location, hash };
+    Object.defineProperty(window, "location", { writable: true, value: location });
+  }
+
+  afterEach(() => setHash(""));
+
+  test("triggers build and submits form automatically when autoStart=true", async () => {
+    localStorage.setItem("jupytherhub-build-token", JSON.stringify({
+      id: "test-id",
+      expires_at: "2099-01-01T00:00:00Z",
+      token: "test-token",
+    }));
+    fetchMock.mockResponseOnce(JSON.stringify({ name: "testuser" }));
+
+    setHash(
+      `#fancy-forms-config=${encodeURIComponent(
+        JSON.stringify({
+          profile: "build-custom-environment",
+          image: "--extra-selectable-item",
+          "image:binderRepo": "org/repo",
+          "image:ref": "HEAD",
+          autoStart: "true",
+        })
+      )}`
+    );
+
+    const { container } = renderWithJupyterForm(<ProfileForm />);
+
+    const form = container.querySelector("form");
+    let hiddenValueAtSubmit = "";
+    const requestSubmitSpy = jest.spyOn(form, "requestSubmit").mockImplementation(() => {
+      const input = form.querySelector("[data-dynamic-build='true']") as HTMLInputElement;
+      hiddenValueAtSubmit = input?.value ?? "";
+    });
+
+    await waitFor(() => expect(requestSubmitSpy).toHaveBeenCalledTimes(1));
+    expect(hiddenValueAtSubmit).toBe("ghcr.io/org/repo:abc123");
+
+    localStorage.removeItem("jupytherhub-build-token");
+    requestSubmitSpy.mockRestore();
+  });
 });

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -174,7 +174,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
 
   const repoRef = permalinkValues[`${optionKey}:ref`];
   const binderRepo= permalinkValues[`${optionKey}:binderRepo`];
-  const { repo, repoId, repoFieldProps, repoError, forceValidation } =
+  const { repoId, repoFieldProps, repoError, forceValidation, resetError } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption, cacheChoiceOption, cacheRepositorySelection } = useFormCache();
   const { setIsImageBuildActive, setFormErrors } = useFormState();
@@ -204,6 +204,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     if (!isActive) {
       setCustomImageError("");
       setHasBuiltImage(false);
+      resetError();
     }
   }, [isActive]);
 
@@ -226,7 +227,6 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     if (hasAutoStarted.current) return;
     hasAutoStarted.current = true;
     handleBuildAndStart();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isActive, term, permalinkValues]);
 
   const handleBuildAndStart = async () => {
@@ -241,6 +241,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
 
     // preBuildValidate only checks required (non-empty). Validate repo format explicitly.
     forceValidation();
+    // If repoID is invalid, it is undefined 
     if (!repoId) {
       collectFormErrors(form, setFormErrors);
       return;
@@ -248,6 +249,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
 
     setIsBuildingImage(true);
     setCustomImageError("");
+    resetError();
     try {
       const imageName = await buildImage(repoId, ref, term, fitAddon);
       customImageRef.current.value = imageName;

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -174,8 +174,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption,
-    setBuildImageStart, isBuildingImage, setIsBuildingImage,
-    setIsDynamicBuildActive } = useFormCache();
+    setBuildImageSelected, isBuildingImage, setIsBuildingImage } = useFormCache();
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const repoFieldRef = useRef<HTMLInputElement>();
@@ -214,8 +213,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
       branchFieldRef.current.blur();
       throw new Error("Git ref is required.");
     }
-    console.log(repo);
-    console.log(repoId);
+
     try {
       setIsBuildingImage(true);
       setCustomImageError("");
@@ -240,24 +238,16 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
 
   useEffect(() => {
     if (!isActive) return;
-    setIsDynamicBuildActive(true);
-    return () => {
-      setIsDynamicBuildActive(false);
-    };
-  }, [isActive, setIsDynamicBuildActive]);
-
-  useEffect(() => {
-    if (!isActive) return;
     // Creating the wrapper so it can read latestBuildHandler.current when it runs. (preventing stale clusure)
     const wrapper = () => {
       const handler = latestBuildHandler.current;
       return handler ? handler() : Promise.resolve();
     };
-    setBuildImageStart(() => wrapper);
+    setBuildImageSelected(() => wrapper);
     return () => {
-      setBuildImageStart(null);
+      setBuildImageSelected(null);
     };
-  }, [isActive, setBuildImageStart]);
+  }, [isActive, setBuildImageSelected]);
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === "Enter") {

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -174,7 +174,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
 
   const repoRef = permalinkValues[`${optionKey}:ref`];
   const binderRepo= permalinkValues[`${optionKey}:binderRepo`];
-  const { repo, repoId, repoFieldProps, repoError } =
+  const { repo, repoId, repoFieldProps, repoError, forceValidation } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption, cacheChoiceOption, cacheRepositorySelection } = useFormCache();
   const { setIsImageBuildActive, setFormErrors } = useFormState();
@@ -239,10 +239,17 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
       return;
     }
 
+    // preBuildValidate only checks required (non-empty). Validate repo format explicitly.
+    forceValidation();
+    if (!repoId) {
+      collectFormErrors(form, setFormErrors);
+      return;
+    }
+
     setIsBuildingImage(true);
     setCustomImageError("");
     try {
-      const imageName = await buildImage(repoId!, ref, term, fitAddon);
+      const imageName = await buildImage(repoId, ref, term, fitAddon);
       customImageRef.current.value = imageName;
       setHasBuiltImage(true);
       term.write("\nImage has been built! Starting your server...");

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useRef, useContext, useMemo, KeyboardEventHandler } from "react";
-import { flushSync } from "react-dom";
 import { type Terminal } from "xterm";
 import { type FitAddon } from "xterm-addon-fit";
 
@@ -180,8 +179,9 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const repoFieldRef = useRef<HTMLInputElement>();
   const branchFieldRef = useRef<HTMLInputElement>();
+  const customImageRef = useRef<HTMLInputElement>(null);
 
-  const [customImage, setCustomImage] = useState<string>("");
+  const [hasBuiltImage, setHasBuiltImage] = useState(false);
   const [customImageError, setCustomImageError] = useState<string>("");
 
   const [term, setTerm] = useState<Terminal>(null);
@@ -199,7 +199,10 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   }
 
   useEffect(() => {
-    if (!isActive) setCustomImageError("");
+    if (!isActive) {
+      setCustomImageError("");
+      setHasBuiltImage(false);
+    }
   }, [isActive]);
 
   const handleBuildStart = async () => {
@@ -219,9 +222,8 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
       setIsBuildingImage(true);
       setCustomImageError("");
       const imageName = await buildImage(repoId!, ref, term, fitAddon);
-      // flushSync forces React to update the hidden input's DOM value synchronously,
-      // so form.requestSubmit() in submitFlow sees the correct value immediately.
-      flushSync(() => { setCustomImage(imageName); });
+      customImageRef.current.value = imageName;
+      setHasBuiltImage(true);
       term.write("\nImage has been built! Starting your server...");
     } catch (e) {
       const message = (e as Error)?.message || "Image build failed.";
@@ -314,14 +316,13 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
       <input
         type="text"
         name={name}
-        value={customImage}
-        aria-invalid={isActive && !customImage}
+        ref={customImageRef}
+        defaultValue=""
+        aria-invalid={isActive && !hasBuiltImage}
         required={isActive}
         aria-hidden="true"
         style={{ display: "none" }}
-        data-dynamic-build="true" 
-        onInvalid={() => {}}
-        onChange={() => {}} // Hack to prevent a console error, while at the same time allowing for this field to be validatable, ie. not making it read-only
+        data-dynamic-build="true"
       />
       <div className="profile-option-container">
         <div className="profile-option-label-container">

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, useContext, useMemo, KeyboardEventHandler } from "react";
+import { createPortal } from "react-dom";
 import { type Terminal } from "xterm";
 import { type FitAddon } from "xterm-addon-fit";
 
@@ -8,6 +9,7 @@ import useFormCache from "./hooks/useFormCache";
 import useFormState from "./hooks/useFormState";
 import { PermalinkContext } from "./context/Permalink";
 import { ICustomOptionProps } from "./types/fields";
+import { cacheFormValues, collectFormErrors, preBuildValidate } from "./utils/formSubmit";
 
 const TOKEN_KEY = "jupytherhub-build-token";
 
@@ -173,12 +175,10 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const binderRepo= permalinkValues[`${optionKey}:binderRepo`];
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
-  const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption } = useFormCache();
-  const { setBuildImageSelected, isBuildingImage, setIsBuildingImage } = useFormState();
+  const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption, cacheChoiceOption, cacheRepositorySelection } = useFormCache();
+  const { setIsImageBuildActive, setFormErrors, isBuildingImage, setIsBuildingImage } = useFormState();
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
-  const repoFieldRef = useRef<HTMLInputElement>();
-  const branchFieldRef = useRef<HTMLInputElement>();
   const customImageRef = useRef<HTMLInputElement>(null);
 
   const [hasBuiltImage, setHasBuiltImage] = useState(false);
@@ -205,58 +205,49 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     }
   }, [isActive]);
 
-  const handleBuildStart = async () => {
-    if (repoFieldRef.current && !repo) {
-      repoFieldRef.current.focus();
-      repoFieldRef.current.blur();
-      throw new Error("Repository is required.");
+  useEffect(() => {
+    if (!isActive) return;
+    setIsImageBuildActive(true);
+    return () => setIsImageBuildActive(false);
+  }, [isActive, setIsImageBuildActive]);
+
+  const [submitSlot, setSubmitSlot] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setSubmitSlot(document.getElementById("submit-slot"));
+  }, []);
+
+  const handleBuildAndStart = async () => {
+    const form = customImageRef.current?.closest("form") as HTMLFormElement | null;
+    if (!form) return;
+
+    if (!preBuildValidate(form)) {
+      collectFormErrors(form, setFormErrors);
+      return;
     }
 
-    if (branchFieldRef.current && !ref) {
-      branchFieldRef.current.focus();
-      branchFieldRef.current.blur();
-      throw new Error("Git ref is required.");
-    }
-
+    setIsBuildingImage(true);
+    setCustomImageError("");
     try {
-      setIsBuildingImage(true);
-      setCustomImageError("");
       const imageName = await buildImage(repoId!, ref, term, fitAddon);
       customImageRef.current.value = imageName;
       setHasBuiltImage(true);
       term.write("\nImage has been built! Starting your server...");
+      cacheFormValues(form, cacheChoiceOption, cacheRepositorySelection);
+      form.requestSubmit();
     } catch (e) {
       const message = (e as Error)?.message || "Image build failed.";
       setCustomImageError(message);
-      throw e;
+      collectFormErrors(form, setFormErrors);
     } finally {
       setIsBuildingImage(false);
     }
   };
 
-  // Single ref that always points at the latest handleBuildStart, so the
-  // stable wrapper registered in the context never sees a stale closure.
-  const latestBuildHandler = useRef<() => Promise<void>>();
-  latestBuildHandler.current = handleBuildStart;
-
-  useEffect(() => {
-    if (!isActive) return;
-    // Creating the wrapper so it can read latestBuildHandler.current when it runs. (preventing stale clusure)
-    const wrapper = () => {
-      const handler = latestBuildHandler.current;
-      return handler ? handler() : Promise.resolve();
-    };
-    setBuildImageSelected(() => wrapper);
-    return () => {
-      setBuildImageSelected(null);
-    };
-  }, [isActive, setBuildImageSelected]);
-
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
       (e.target as HTMLInputElement).blur();
-      handleBuildStart().catch(() => {});
+      void handleBuildAndStart();
     }
   };
 
@@ -275,7 +266,6 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
         id={`${name}--repo`}
         className={isActive ? "cache-repository" : undefined}
         label="Repository"
-        ref={repoFieldRef}
         {...repoFieldProps}
         error={repoError}
         options={repositoryOptions}
@@ -292,7 +282,6 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
       <Combobox
         id={`${name}--ref`}
         label="Git Ref"
-        ref={branchFieldRef}
         hint="Branch, Tag or Commit to use. HEAD will use the default branch"
         value={ref}
         validate={
@@ -342,6 +331,17 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
           )}
         </div>
       </div>
+      {isActive && submitSlot && createPortal(
+        <button
+          className="btn btn-jupyter form-control"
+          type="submit"
+          onClick={(e) => { e.preventDefault(); void handleBuildAndStart(); }}
+          disabled={isBuildingImage}
+        >
+          Build Image and Start
+        </button>,
+        submitSlot
+      )}
     </>
   );
 }

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -361,8 +361,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
         >
           {isBuildingImage
             ? <><LuRotateCcw className="spin" />Building...</>
-            : "Build Image and Start"
-          }
+            : "Build Image and Start"}
         </button>,
         submitSlot
       )}

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -6,6 +6,7 @@ import { type FitAddon } from "xterm-addon-fit";
 import useRepositoryField from "./hooks/useRepositoryField";
 import Combobox from "./components/form/Combobox";
 import useFormCache from "./hooks/useFormCache";
+import useFormState from "./hooks/useFormState";
 import { PermalinkContext } from "./context/Permalink";
 import { ICustomOptionProps } from "./types/fields";
 
@@ -173,8 +174,8 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const binderRepo= permalinkValues[`${optionKey}:binderRepo`];
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
-  const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption,
-    setBuildImageSelected, isBuildingImage, setIsBuildingImage } = useFormCache();
+  const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption } = useFormCache();
+  const { setBuildImageSelected, isBuildingImage, setIsBuildingImage } = useFormState();
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const repoFieldRef = useRef<HTMLInputElement>();

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -269,6 +269,8 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
+      // Because it is rendered through portal, the event bubbles to React parent
+      e.stopPropagation();
       (e.target as HTMLInputElement).blur();
       handleBuildAndStart();
     }
@@ -358,7 +360,8 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
         <button
           className="btn btn-jupyter form-control"
           type="submit"
-          onClick={(e) => { e.preventDefault(); handleBuildAndStart(); }}
+          // Because it is rendered through portal, the event bubbles to React parent
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleBuildAndStart(); }}
           disabled={isBuildingImage}
         >
           {isBuildingImage

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -10,6 +10,7 @@ import useFormState from "./hooks/useFormState";
 import { PermalinkContext } from "./context/Permalink";
 import { ICustomOptionProps } from "./types/fields";
 import { cacheFormValues, collectFormErrors, preBuildValidate } from "./utils/formSubmit";
+import { LuRotateCcw } from "react-icons/lu";
 
 const TOKEN_KEY = "jupytherhub-build-token";
 
@@ -176,7 +177,8 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption, cacheChoiceOption, cacheRepositorySelection } = useFormCache();
-  const { setIsImageBuildActive, setFormErrors, isBuildingImage, setIsBuildingImage } = useFormState();
+  const { setIsImageBuildActive, setFormErrors } = useFormState();
+  const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const customImageRef = useRef<HTMLInputElement>(null);
@@ -217,6 +219,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
   }, []);
 
   const handleBuildAndStart = async () => {
+    if (!customImageRef.current ) return;
     const form = customImageRef.current?.closest("form") as HTMLFormElement | null;
     if (!form) return;
 
@@ -247,7 +250,7 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     if (e.key === "Enter") {
       e.preventDefault();
       (e.target as HTMLInputElement).blur();
-      void handleBuildAndStart();
+      handleBuildAndStart();
     }
   };
 
@@ -335,10 +338,13 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
         <button
           className="btn btn-jupyter form-control"
           type="submit"
-          onClick={(e) => { e.preventDefault(); void handleBuildAndStart(); }}
+          onClick={(e) => { e.preventDefault(); handleBuildAndStart(); }}
           disabled={isBuildingImage}
         >
-          Build Image and Start
+          {isBuildingImage
+            ? <><LuRotateCcw className="spin" />Building...</>
+            : "Build Image and Start"
+          }
         </button>,
         submitSlot
       )}

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -218,6 +218,17 @@ export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) 
     setSubmitSlot(document.getElementById("submit-slot"));
   }, []);
 
+  const hasAutoStarted = useRef(false);
+  useEffect(() => {
+    if (!isActive) return;
+    if (!term) return;
+    if (permalinkValues["autoStart"] !== "true") return;
+    if (hasAutoStarted.current) return;
+    hasAutoStarted.current = true;
+    handleBuildAndStart();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isActive, term, permalinkValues]);
+
   const handleBuildAndStart = async () => {
     if (!customImageRef.current ) return;
     const form = customImageRef.current?.closest("form") as HTMLFormElement | null;

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -1,6 +1,8 @@
-import { describe, expect, test } from "@jest/globals";
-import { screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+afterEach(cleanup);
 
 import ProfileForm from "./ProfileForm";
 import renderWithContext, { renderWithJupyterForm } from "./test/renderWithContext";

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -330,6 +330,27 @@ describe("Profile form with URL Params", () => {
 
 });
 
+describe("autoStart", () => {
+  function setHash(hash: string) {
+    const location = { ...window.location, hash };
+    Object.defineProperty(window, "location", { writable: true, value: location });
+  }
+
+  afterEach(() => setHash(""));
+
+  test("submits form immediately for non-build profile", async () => {
+    const requestSubmitSpy = jest
+      .spyOn(HTMLFormElement.prototype, "requestSubmit")
+      .mockImplementation(() => {});
+
+    setHash(`#fancy-forms-config=${encodeURIComponent(JSON.stringify({ profile: "cpu", image: "geospatial", autoStart: "true" }))}`);
+    renderWithJupyterForm(<ProfileForm />);
+
+    await waitFor(() => expect(requestSubmitSpy).toHaveBeenCalled());
+    requestSubmitSpy.mockRestore();
+  });
+});
+
 describe("submit slot", () => {
   test("submit button renders inside #submit-slot", async () => {
     const { container } = renderWithJupyterForm(<ProfileForm />);
@@ -337,20 +358,5 @@ describe("submit slot", () => {
     expect(container.querySelector("#submit-slot")).toContainElement(startButton);
   });
 
-  test("'Build Image and Start' button renders in submit-slot when build option is active", async () => {
-    const user = userEvent.setup();
-    const { container } = renderWithJupyterForm(<ProfileForm />);
 
-    await user.click(screen.getByRole("radio", {
-      name: "Build custom environment Dynamic Image building + unlisted choice",
-    }));
-
-    const imageSelect = screen.getByLabelText("Image - dynamic image building");
-    await user.click(imageSelect);
-    await user.click(screen.getByText("Build your own image"));
-
-    expect(screen.queryByRole("button", { name: "Start" })).not.toBeInTheDocument();
-    const buildButton = screen.getByRole("button", { name: "Build Image and Start" });
-    expect(container.querySelector("#submit-slot")).toContainElement(buildButton);
-  });
 });

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -104,6 +104,29 @@ describe("Profile form", () => {
     ).toBeInTheDocument();
   });
 
+  test("invalid docker image format blocks form submission without blur", async () => {
+    const user = userEvent.setup();
+    const requestSubmitSpy = jest.spyOn(HTMLFormElement.prototype, "requestSubmit").mockImplementation(() => {});
+
+    renderWithJupyterForm(<ProfileForm />);
+
+    await user.click(screen.getByRole("radio", { name: "CPU only No GPU, only CPU" }));
+    await user.click(screen.getByLabelText("Image"));
+    await user.click(screen.getByText("Specify an existing docker image"));
+
+    // Type an invalid format (no colon) without explicitly blurring first
+    await user.type(screen.getByLabelText("Custom image"), "ubuntu");
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    expect(requestSubmitSpy).not.toHaveBeenCalled();
+    await waitFor(() => expect(
+      screen.getByText("Must be a publicly available docker image, of form <image-name>:<tag>")
+    ).toBeInTheDocument());
+
+    requestSubmitSpy.mockRestore();
+  });
+
   test("custom image field accepts specific format", async () => {
     const user = userEvent.setup();
 

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -336,4 +336,21 @@ describe("submit slot", () => {
     const startButton = screen.getByRole("button", { name: "Start" });
     expect(container.querySelector("#submit-slot")).toContainElement(startButton);
   });
+
+  test("'Build Image and Start' button renders in submit-slot when build option is active", async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithJupyterForm(<ProfileForm />);
+
+    await user.click(screen.getByRole("radio", {
+      name: "Build custom environment Dynamic Image building + unlisted choice",
+    }));
+
+    const imageSelect = screen.getByLabelText("Image - dynamic image building");
+    await user.click(imageSelect);
+    await user.click(screen.getByText("Build your own image"));
+
+    expect(screen.queryByRole("button", { name: "Start" })).not.toBeInTheDocument();
+    const buildButton = screen.getByRole("button", { name: "Build Image and Start" });
+    expect(container.querySelector("#submit-slot")).toContainElement(buildButton);
+  });
 });

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -258,6 +258,8 @@ describe("Profile form with URL Params", () => {
     });
   }
 
+  afterEach(() => setHash(""));
+
   test("ignores irrelevant params", () => {
     setHash("#foo=bar");
     const { container } = renderWithContext(<ProfileForm />);
@@ -324,5 +326,14 @@ describe("Profile form with URL Params", () => {
       name: "No Options Profile with no options",
     });
     expect(noObject).toBeInTheDocument();
+  });
+
+});
+
+describe("submit slot", () => {
+  test("submit button renders inside #submit-slot", async () => {
+    const { container } = renderWithJupyterForm(<ProfileForm />);
+    const startButton = screen.getByRole("button", { name: "Start" });
+    expect(container.querySelector("#submit-slot")).toContainElement(startButton);
   });
 });

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -121,8 +121,8 @@ describe("Profile form", () => {
 
     expect(requestSubmitSpy).not.toHaveBeenCalled();
     await waitFor(() => expect(
-      screen.getByText("Must be a publicly available docker image, of form <image-name>:<tag>")
-    ).toBeInTheDocument());
+      screen.getAllByText("Must be a publicly available docker image, of form <image-name>:<tag>").length
+    ).toBeGreaterThanOrEqual(1));
 
     requestSubmitSpy.mockRestore();
   });
@@ -308,6 +308,7 @@ describe("Profile form with URL Params", () => {
   });
 
   test("shows error for malformed config", () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     setHash("#fancy-forms-config=%7B%22profile%22%3A%22build-custom-environment%22%2C%22image%22%3A%22--extra-selectable-item%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22image%3AbinderProvider%22%3A%22gh%22%2C%22image%3AbinderRepo%22%3A%22org%2Fre");
     const { container } = renderWithContext(<ProfileForm />);
     const hiddenRadio = container.querySelector("[name='profile']");
@@ -317,6 +318,7 @@ describe("Profile form with URL Params", () => {
     });
     expect((defaultRadio as HTMLInputElement).checked).toBeTruthy();
     expect(screen.queryByText("Unable to parse permalink configuration.")).toBeInTheDocument();
+    consoleSpy.mockRestore();
   });
 
   test("preselects values", async () => {

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -11,6 +11,7 @@ import "./form.css";
 import { SpawnerFormContext } from "./state";
 import { ProfileOptions } from "./ProfileOptions";
 import useFormCache from "./hooks/useFormCache";
+import useFormState from "./hooks/useFormState";
 import { PermalinkContext } from "./context/Permalink";
 import Permalink from "./components/Permalink";
 import { cacheFormValues, collectFormErrors, preBuildValidate } from "./utils/formSubmit";
@@ -30,13 +31,13 @@ function Form() {
   } = useContext(SpawnerFormContext);
   const { permalinkValues, setPermalinkValue, permalinkParseError } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
-  const [formErrors, setFormErrors] = useState<Element[]>([]);
   const {
     cacheChoiceOption,
     cacheRepositorySelection,
     buildImageSelected,
     isBuildingImage,
   } = useFormCache();
+  const { formErrors, setFormErrors } = useFormState();
   const isDynamicBuildActive = buildImageSelected !== null;
 
   const submitFlow = async (

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -74,6 +74,7 @@ function Form() {
     setProfile(slug);
     setPermalinkValue("profile", slug);
     setProfileError("");
+    setFormErrors([]);
   };
 
   useEffect(() => {
@@ -131,6 +132,8 @@ function Form() {
             onClick={() => {
               setProfile(slug);
               setPermalinkValue("profile", slug);
+              setProfileError("");
+              setFormErrors([]);
             }}
           >
             {profileList.length > 1 && (

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -31,13 +31,8 @@ function Form() {
   } = useContext(SpawnerFormContext);
   const { permalinkValues, setPermalinkValue, permalinkParseError } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
-  const {
-    cacheChoiceOption,
-    cacheRepositorySelection,
-    buildImageSelected,
-    isBuildingImage,
-  } = useFormCache();
-  const { formErrors, setFormErrors } = useFormState();
+  const { cacheChoiceOption, cacheRepositorySelection } = useFormCache();
+  const { formErrors, setFormErrors, buildImageSelected, isBuildingImage } = useFormState();
   const isDynamicBuildActive = buildImageSelected !== null;
 
   const submitFlow = async (

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -220,14 +220,16 @@ function Form() {
         </div>
       )}
 
-      <button
-        className="btn btn-jupyter form-control"
-        type="submit"
-        onClick={handleSubmit}
-        disabled={isBuildingImage}
-      >
-        {isDynamicBuildActive ? "Build Image and Start" : "Start"}
-      </button>
+      <div id="submit-slot">
+        <button
+          className="btn btn-jupyter form-control"
+          type="submit"
+          onClick={handleSubmit}
+          disabled={isBuildingImage}
+        >
+          {isDynamicBuildActive ? "Build Image and Start" : "Start"}
+        </button>
+      </div>
     </fieldset>
   );
 }

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -13,6 +13,7 @@ import { ProfileOptions } from "./ProfileOptions";
 import useFormCache from "./hooks/useFormCache";
 import { PermalinkContext } from "./context/Permalink";
 import Permalink from "./components/Permalink";
+import { cacheFormValues, collectFormErrors, preBuildValidate } from "./utils/formSubmit";
 
 /**
  * Generates the *contents* of the form shown in the profile selection page
@@ -38,54 +39,6 @@ function Form() {
   } = useFormCache();
   const isDynamicBuildActive = buildImageSelected !== null;
 
-
-  const collectFormErrors = (form: HTMLFormElement) => {
-    setTimeout(() => {
-      const errors = form.getElementsByClassName("invalid-feedback");
-      setFormErrors(Array.from(errors));
-    }, 10);
-    setTimeout(() => {
-      window.scrollTo(0, document.body.scrollHeight);
-    }, 100);
-  };
-
-  const cacheFormValues = (form: HTMLFormElement) => {
-    const cacheUnlistedChoices = form.getElementsByClassName("cache-unlisted-choice");
-    Array.from(cacheUnlistedChoices).forEach((el) => {
-      const { id, value } = el as HTMLInputElement;
-      cacheChoiceOption(id, value);
-    });
-
-    const cacheRepositories = form.getElementsByClassName("cache-repository");
-    Array.from(cacheRepositories).forEach((el) => {
-      const { id, value } = el as HTMLInputElement;
-      if (id.endsWith("--repo")) {
-        const fieldName = id.slice(0, -6);
-        const refField = form.querySelector(`#${CSS.escape(`${fieldName}--ref`)}`);
-        if (refField) {
-          cacheRepositorySelection(fieldName, value, (refField as HTMLInputElement).value);
-        }
-      }
-    });
-  };
-
-  const preBuildValidate = (form: HTMLFormElement): boolean => {
-    let firstInvalid: HTMLInputElement | null = null;
-    form.querySelectorAll<HTMLInputElement>("input, select, textarea").forEach((field) => {
-      // Hidden text input for dynamically buit image name (input is empty)
-      if (field.dataset.dynamicBuild === "true") return;
-      if (field.disabled) return;
-      if (!field.checkValidity()) {
-        if (!firstInvalid) firstInvalid = field;
-      }
-    });
-    if (firstInvalid) {
-      firstInvalid!.reportValidity();
-      return false;
-    }
-    return true;
-  };
-
   const submitFlow = async (
     form: HTMLFormElement | null,
     nativeEvent?: { preventDefault: () => void },
@@ -104,30 +57,30 @@ function Form() {
       nativeEvent?.preventDefault();
       // but there is an error in form
       if (!preBuildValidate(form)) {
-        collectFormErrors(form);
+        collectFormErrors(form, setFormErrors);
         return false;
       }
 
       try {
         await buildImageSelected();
       } catch {
-        collectFormErrors(form);
+        collectFormErrors(form, setFormErrors);
         return false;
       }
 
-      cacheFormValues(form);
+      cacheFormValues(form, cacheChoiceOption, cacheRepositorySelection);
       form.requestSubmit();
       return true;
     }
 
     if (form && !form.checkValidity()) {
       nativeEvent?.preventDefault();
-      collectFormErrors(form);
+      collectFormErrors(form, setFormErrors);
       return false;
     }
 
     if (form) {
-      cacheFormValues(form);
+      cacheFormValues(form, cacheChoiceOption, cacheRepositorySelection);
     }
     // When submit happened by mimicking the button (from query parameter)
     if (!nativeEvent) {

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -14,7 +14,7 @@ import useFormCache from "./hooks/useFormCache";
 import useFormState from "./hooks/useFormState";
 import { PermalinkContext } from "./context/Permalink";
 import Permalink from "./components/Permalink";
-import { cacheFormValues, collectFormErrors, preBuildValidate } from "./utils/formSubmit";
+import { cacheFormValues, collectFormErrors } from "./utils/formSubmit";
 
 /**
  * Generates the *contents* of the form shown in the profile selection page
@@ -32,8 +32,7 @@ function Form() {
   const { permalinkValues, setPermalinkValue, permalinkParseError } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
   const { cacheChoiceOption, cacheRepositorySelection } = useFormCache();
-  const { formErrors, setFormErrors, buildImageSelected, isBuildingImage } = useFormState();
-  const isDynamicBuildActive = buildImageSelected !== null;
+  const { formErrors, setFormErrors, isImageBuildActive } = useFormState();
 
   const submitFlow = async (
     form: HTMLFormElement | null,
@@ -47,28 +46,6 @@ function Form() {
       setProfileError("Select a container profile");
       return false;
     }
-    // when dynamic image build is requested
-    if (buildImageSelected) {
-      if (!form) return false;
-      nativeEvent?.preventDefault();
-      // but there is an error in form
-      if (!preBuildValidate(form)) {
-        collectFormErrors(form, setFormErrors);
-        return false;
-      }
-
-      try {
-        await buildImageSelected();
-      } catch {
-        collectFormErrors(form, setFormErrors);
-        return false;
-      }
-
-      cacheFormValues(form, cacheChoiceOption, cacheRepositorySelection);
-      form.requestSubmit();
-      return true;
-    }
-
     if (form && !form.checkValidity()) {
       nativeEvent?.preventDefault();
       collectFormErrors(form, setFormErrors);
@@ -221,14 +198,15 @@ function Form() {
       )}
 
       <div id="submit-slot">
-        <button
-          className="btn btn-jupyter form-control"
-          type="submit"
-          onClick={handleSubmit}
-          disabled={isBuildingImage}
-        >
-          {isDynamicBuildActive ? "Build Image and Start" : "Start"}
-        </button>
+        {!isImageBuildActive && (
+          <button
+            className="btn btn-jupyter form-control"
+            type="submit"
+            onClick={handleSubmit}
+          >
+            Start
+          </button>
+        )}
       </div>
     </fieldset>
   );

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -33,10 +33,10 @@ function Form() {
   const {
     cacheChoiceOption,
     cacheRepositorySelection,
-    buildImageStart,
+    buildImageSelected,
     isBuildingImage,
-    isDynamicBuildActive,
   } = useFormCache();
+  const isDynamicBuildActive = buildImageSelected !== null;
 
 
   const collectFormErrors = (form: HTMLFormElement) => {
@@ -99,7 +99,7 @@ function Form() {
       return false;
     }
     // when dynamic image build is requested
-    if (isDynamicBuildActive && buildImageStart) {
+    if (buildImageSelected) {
       if (!form) return false;
       nativeEvent?.preventDefault();
       // but there is an error in form
@@ -109,7 +109,7 @@ function Form() {
       }
 
       try {
-        await buildImageStart();
+        await buildImageSelected();
       } catch {
         collectFormErrors(form);
         return false;

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -96,21 +96,14 @@ function Form() {
     }
   }, [permalinkValues.profile]);
 
-  // @TODO: Replace setTimeout (hack for racing condition) + dispatchEvent (hack for stale closure)
-  // to proper sequencing of the events and calling submitflow directly
+  // Run autostart once on mount.
   useEffect(() => {
-    if (permalinkValues["autoStart"] === "true") {
-      const form = document.querySelector("form");
-      if (form) {
-        const button = form.querySelector("button[type=\"submit\"]") as HTMLButtonElement | null;
-        if (button) {
-          setTimeout(() => {
-            button.dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
-          }, 1000); // Give the form a second to render, and the profile to be selected, HACK but it works
-        }
-      }
-    }
-  }, [permalinkValues]);
+    if (permalinkValues["autoStart"] !== "true") return;
+    const form = document.querySelector("form") as HTMLFormElement | null;
+    if (!form) return;
+    if (form.querySelector("[data-dynamic-build='true'][required]")) return;
+    submitFlow(form);
+  }, []);
 
   return (
     <fieldset

--- a/src/ResourceSelect.tsx
+++ b/src/ResourceSelect.tsx
@@ -50,6 +50,7 @@ function ResourceSelect({
 
   const selectedCustomOption = customOptions.find((opt) => opt.value === value);
   const choiceOptions = getChoiceOptions(FIELD_ID_UNLISTED);
+
   return (
     <>
       {(options.length > 1 || hasDefaultChoices) && (

--- a/src/components/form/Combobox.tsx
+++ b/src/components/form/Combobox.tsx
@@ -156,6 +156,7 @@ function Combobox(
 
   const listboxId = `${id}-listbox`;
   const required = !!validate.required;
+  const pattern = typeof validate === "object" ? validate.pattern?.value : undefined;
   const validateError = validateField(value, validate, touched);
 
   return (
@@ -184,6 +185,7 @@ function Combobox(
         onInvalid={() => setTouched(true)}
         tabIndex={tabIndex}
         required={required}
+        pattern={pattern}
         ref={fieldRef}
         style={{ position: "relative" }}
       />

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -24,12 +24,10 @@ export interface IFormCache {
     ref: string,
   ) => void;
 
-  buildImageStart: (() => Promise<void>) | null;
-  setBuildImageStart: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
+  buildImageSelected: (() => Promise<void>) | null;
+  setBuildImageSelected: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
   isBuildingImage: boolean;
   setIsBuildingImage: Dispatch<SetStateAction<boolean>>;
-  isDynamicBuildActive: boolean;
-  setIsDynamicBuildActive: Dispatch<SetStateAction<boolean>>;
 }
 
 type TChoiceEntry = {
@@ -163,9 +161,8 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     loadPreviousRepositories();
   }, []);
 
-  const [buildImageStart, setBuildImageStart] = useState<(() => Promise<void>) | null>(null);
+  const [buildImageSelected, setBuildImageSelected] = useState<(() => Promise<void>) | null>(null);
   const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
-  const [isDynamicBuildActive, setIsDynamicBuildActive] = useState<boolean>(false);
 
   const contextValue = useMemo(() => ({
     getChoiceOptions,
@@ -176,12 +173,10 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     removeChoiceOption,
     removeRepositoryOption,
     removeRefOption,
-    buildImageStart,
-    setBuildImageStart,
+    buildImageSelected,
+    setBuildImageSelected,
     isBuildingImage,
     setIsBuildingImage,
-    isDynamicBuildActive,
-    setIsDynamicBuildActive,
   }), [
     getChoiceOptions,
     cacheChoiceOption,
@@ -191,12 +186,10 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     removeChoiceOption,
     removeRepositoryOption,
     removeRefOption,
-    buildImageStart,
-    setBuildImageStart,
+    buildImageSelected,
+    setBuildImageSelected,
     isBuildingImage,
     setIsBuildingImage,
-    isDynamicBuildActive,
-    setIsDynamicBuildActive,
   ]);
 
   return (

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -5,8 +5,6 @@ import {
   useEffect,
   useState,
   useMemo,
-  Dispatch,
-  SetStateAction
 } from "react";
 import { cacheOption, getRecords, removeOption, removeRepository } from "../utils/indexedDb";
 
@@ -23,11 +21,6 @@ export interface IFormCache {
     repository: string,
     ref: string,
   ) => void;
-
-  buildImageSelected: (() => Promise<void>) | null;
-  setBuildImageSelected: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
-  isBuildingImage: boolean;
-  setIsBuildingImage: Dispatch<SetStateAction<boolean>>;
 }
 
 type TChoiceEntry = {
@@ -161,9 +154,6 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     loadPreviousRepositories();
   }, []);
 
-  const [buildImageSelected, setBuildImageSelected] = useState<(() => Promise<void>) | null>(null);
-  const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
-
   const contextValue = useMemo(() => ({
     getChoiceOptions,
     cacheChoiceOption,
@@ -173,10 +163,6 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     removeChoiceOption,
     removeRepositoryOption,
     removeRefOption,
-    buildImageSelected,
-    setBuildImageSelected,
-    isBuildingImage,
-    setIsBuildingImage,
   }), [
     getChoiceOptions,
     cacheChoiceOption,
@@ -186,10 +172,6 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     removeChoiceOption,
     removeRepositoryOption,
     removeRefOption,
-    buildImageSelected,
-    setBuildImageSelected,
-    isBuildingImage,
-    setIsBuildingImage,
   ]);
 
   return (

--- a/src/context/FormState.tsx
+++ b/src/context/FormState.tsx
@@ -13,8 +13,6 @@ export interface IFormState {
 
   isImageBuildActive: boolean;
   setIsImageBuildActive: Dispatch<SetStateAction<boolean>>;
-  isBuildingImage: boolean;
-  setIsBuildingImage: Dispatch<SetStateAction<boolean>>;
 }
 
 export const FormStateContext = createContext<IFormState>(null);
@@ -22,22 +20,17 @@ export const FormStateContext = createContext<IFormState>(null);
 export const FormStateProvider = ({ children }: PropsWithChildren) => {
   const [formErrors, setFormErrors] = useState<Element[]>([]);
   const [isImageBuildActive, setIsImageBuildActive] = useState<boolean>(false);
-  const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
 
   const contextValue = useMemo(() => ({
     formErrors,
     setFormErrors,
     isImageBuildActive,
     setIsImageBuildActive,
-    isBuildingImage,
-    setIsBuildingImage,
   }), [
     formErrors,
     setFormErrors,
     isImageBuildActive,
     setIsImageBuildActive,
-    isBuildingImage,
-    setIsBuildingImage,
   ]);
 
   return (

--- a/src/context/FormState.tsx
+++ b/src/context/FormState.tsx
@@ -1,0 +1,33 @@
+import {
+  createContext,
+  PropsWithChildren,
+  useState,
+  useMemo,
+  Dispatch,
+  SetStateAction
+} from "react";
+
+export interface IFormState {
+  formErrors: Element[];
+  setFormErrors: Dispatch<SetStateAction<Element[]>>;
+}
+
+export const FormStateContext = createContext<IFormState>(null);
+
+export const FormStateProvider = ({ children }: PropsWithChildren) => {
+  const [formErrors, setFormErrors] = useState<Element[]>([]);
+
+  const contextValue = useMemo(() => ({
+    formErrors,
+    setFormErrors,
+  }), [
+    formErrors,
+    setFormErrors,
+  ]);
+
+  return (
+    <FormStateContext.Provider value={contextValue}>
+      {children}
+    </FormStateContext.Provider>
+  );
+};

--- a/src/context/FormState.tsx
+++ b/src/context/FormState.tsx
@@ -11,8 +11,8 @@ export interface IFormState {
   formErrors: Element[];
   setFormErrors: Dispatch<SetStateAction<Element[]>>;
 
-  buildImageSelected: (() => Promise<void>) | null;
-  setBuildImageSelected: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
+  isImageBuildActive: boolean;
+  setIsImageBuildActive: Dispatch<SetStateAction<boolean>>;
   isBuildingImage: boolean;
   setIsBuildingImage: Dispatch<SetStateAction<boolean>>;
 }
@@ -21,21 +21,21 @@ export const FormStateContext = createContext<IFormState>(null);
 
 export const FormStateProvider = ({ children }: PropsWithChildren) => {
   const [formErrors, setFormErrors] = useState<Element[]>([]);
-  const [buildImageSelected, setBuildImageSelected] = useState<(() => Promise<void>) | null>(null);
+  const [isImageBuildActive, setIsImageBuildActive] = useState<boolean>(false);
   const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
 
   const contextValue = useMemo(() => ({
     formErrors,
     setFormErrors,
-    buildImageSelected,
-    setBuildImageSelected,
+    isImageBuildActive,
+    setIsImageBuildActive,
     isBuildingImage,
     setIsBuildingImage,
   }), [
     formErrors,
     setFormErrors,
-    buildImageSelected,
-    setBuildImageSelected,
+    isImageBuildActive,
+    setIsImageBuildActive,
     isBuildingImage,
     setIsBuildingImage,
   ]);

--- a/src/context/FormState.tsx
+++ b/src/context/FormState.tsx
@@ -10,19 +10,34 @@ import {
 export interface IFormState {
   formErrors: Element[];
   setFormErrors: Dispatch<SetStateAction<Element[]>>;
+
+  buildImageSelected: (() => Promise<void>) | null;
+  setBuildImageSelected: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
+  isBuildingImage: boolean;
+  setIsBuildingImage: Dispatch<SetStateAction<boolean>>;
 }
 
 export const FormStateContext = createContext<IFormState>(null);
 
 export const FormStateProvider = ({ children }: PropsWithChildren) => {
   const [formErrors, setFormErrors] = useState<Element[]>([]);
+  const [buildImageSelected, setBuildImageSelected] = useState<(() => Promise<void>) | null>(null);
+  const [isBuildingImage, setIsBuildingImage] = useState<boolean>(false);
 
   const contextValue = useMemo(() => ({
     formErrors,
     setFormErrors,
+    buildImageSelected,
+    setBuildImageSelected,
+    isBuildingImage,
+    setIsBuildingImage,
   }), [
     formErrors,
     setFormErrors,
+    buildImageSelected,
+    setBuildImageSelected,
+    isBuildingImage,
+    setIsBuildingImage,
   ]);
 
   return (

--- a/src/form.css
+++ b/src/form.css
@@ -105,6 +105,18 @@
   margin-top: 0.5rem;
 }
 
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+  display: inline-block;
+  margin-right: 0.4rem;
+  vertical-align: middle;
+}
+
 .right-button {
   text-align: right;
   margin-bottom: 2rem;

--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -11,10 +11,6 @@ function useFormCache(): IFormCache {
     removeChoiceOption,
     removeRepositoryOption,
     removeRefOption,
-    buildImageSelected,
-    setBuildImageSelected,
-    isBuildingImage,
-    setIsBuildingImage,
   } = useContext(FormCacheContext) as IFormCache;
 
   return useMemo(
@@ -27,10 +23,6 @@ function useFormCache(): IFormCache {
       removeChoiceOption,
       removeRepositoryOption,
       removeRefOption,
-      buildImageSelected,
-      setBuildImageSelected,
-      isBuildingImage,
-      setIsBuildingImage,
     }),
     [
       getChoiceOptions,
@@ -41,10 +33,6 @@ function useFormCache(): IFormCache {
       removeChoiceOption,
       removeRepositoryOption,
       removeRefOption,
-      buildImageSelected,
-      setBuildImageSelected,
-      isBuildingImage,
-      setIsBuildingImage,
     ],
   );
 }

--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -11,12 +11,10 @@ function useFormCache(): IFormCache {
     removeChoiceOption,
     removeRepositoryOption,
     removeRefOption,
-    buildImageStart,
-    setBuildImageStart,
+    buildImageSelected,
+    setBuildImageSelected,
     isBuildingImage,
     setIsBuildingImage,
-    isDynamicBuildActive,
-    setIsDynamicBuildActive,
   } = useContext(FormCacheContext) as IFormCache;
 
   return useMemo(
@@ -29,12 +27,10 @@ function useFormCache(): IFormCache {
       removeChoiceOption,
       removeRepositoryOption,
       removeRefOption,
-      buildImageStart,
-      setBuildImageStart,
+      buildImageSelected,
+      setBuildImageSelected,
       isBuildingImage,
       setIsBuildingImage,
-      isDynamicBuildActive,
-      setIsDynamicBuildActive,
     }),
     [
       getChoiceOptions,
@@ -45,12 +41,10 @@ function useFormCache(): IFormCache {
       removeChoiceOption,
       removeRepositoryOption,
       removeRefOption,
-      buildImageStart,
-      setBuildImageStart,
+      buildImageSelected,
+      setBuildImageSelected,
       isBuildingImage,
       setIsBuildingImage,
-      isDynamicBuildActive,
-      setIsDynamicBuildActive,
     ],
   );
 }

--- a/src/hooks/useFormState.ts
+++ b/src/hooks/useFormState.ts
@@ -2,14 +2,32 @@ import { useContext, useMemo } from "react";
 import { FormStateContext, IFormState } from "../context/FormState";
 
 function useFormState(): IFormState {
-  const { formErrors, setFormErrors } = useContext(FormStateContext) as IFormState;
+  const {
+    formErrors,
+    setFormErrors,
+    buildImageSelected,
+    setBuildImageSelected,
+    isBuildingImage,
+    setIsBuildingImage,
+  } = useContext(FormStateContext) as IFormState;
 
   return useMemo(
     () => ({
       formErrors,
       setFormErrors,
+      buildImageSelected,
+      setBuildImageSelected,
+      isBuildingImage,
+      setIsBuildingImage,
     }),
-    [formErrors, setFormErrors],
+    [
+      formErrors,
+      setFormErrors,
+      buildImageSelected,
+      setBuildImageSelected,
+      isBuildingImage,
+      setIsBuildingImage,
+    ],
   );
 }
 

--- a/src/hooks/useFormState.ts
+++ b/src/hooks/useFormState.ts
@@ -1,0 +1,16 @@
+import { useContext, useMemo } from "react";
+import { FormStateContext, IFormState } from "../context/FormState";
+
+function useFormState(): IFormState {
+  const { formErrors, setFormErrors } = useContext(FormStateContext) as IFormState;
+
+  return useMemo(
+    () => ({
+      formErrors,
+      setFormErrors,
+    }),
+    [formErrors, setFormErrors],
+  );
+}
+
+export default useFormState;

--- a/src/hooks/useFormState.ts
+++ b/src/hooks/useFormState.ts
@@ -5,8 +5,8 @@ function useFormState(): IFormState {
   const {
     formErrors,
     setFormErrors,
-    buildImageSelected,
-    setBuildImageSelected,
+    isImageBuildActive,
+    setIsImageBuildActive,
     isBuildingImage,
     setIsBuildingImage,
   } = useContext(FormStateContext) as IFormState;
@@ -15,16 +15,16 @@ function useFormState(): IFormState {
     () => ({
       formErrors,
       setFormErrors,
-      buildImageSelected,
-      setBuildImageSelected,
+      isImageBuildActive,
+      setIsImageBuildActive,
       isBuildingImage,
       setIsBuildingImage,
     }),
     [
       formErrors,
       setFormErrors,
-      buildImageSelected,
-      setBuildImageSelected,
+      isImageBuildActive,
+      setIsImageBuildActive,
       isBuildingImage,
       setIsBuildingImage,
     ],

--- a/src/hooks/useFormState.ts
+++ b/src/hooks/useFormState.ts
@@ -7,8 +7,6 @@ function useFormState(): IFormState {
     setFormErrors,
     isImageBuildActive,
     setIsImageBuildActive,
-    isBuildingImage,
-    setIsBuildingImage,
   } = useContext(FormStateContext) as IFormState;
 
   return useMemo(
@@ -17,16 +15,12 @@ function useFormState(): IFormState {
       setFormErrors,
       isImageBuildActive,
       setIsImageBuildActive,
-      isBuildingImage,
-      setIsBuildingImage,
     }),
     [
       formErrors,
       setFormErrors,
       isImageBuildActive,
       setIsImageBuildActive,
-      isBuildingImage,
-      setIsBuildingImage,
     ],
   );
 }

--- a/src/hooks/useRepositoryField.ts
+++ b/src/hooks/useRepositoryField.ts
@@ -34,8 +34,13 @@ export default function useRepositoryField(defaultValue: string) {
     }
   }, [defaultValue]);
 
+  const resetError = useCallback(() => {
+    setError(undefined);
+  }, []);
+
   const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
     setValue(e.target.value);
+    setError(undefined);
   }, []);
 
   // Show format error without trimming — for use when a button is clicked before blur
@@ -54,6 +59,7 @@ export default function useRepositoryField(defaultValue: string) {
     repoError: error,
     repoId,
     forceValidation,
+    resetError,
     repoFieldProps: {
       value,
       onChange,

--- a/src/hooks/useRepositoryField.ts
+++ b/src/hooks/useRepositoryField.ts
@@ -1,6 +1,6 @@
 import { ChangeEventHandler, useCallback, useEffect, useState } from "react";
 
-function extractOrgAndRepo(value: string) {
+export function extractOrgAndRepo(value: string) {
   let orgRepoString;
   const orgRepoMatch = /^[^/]+\/[^/]+$/.exec(value);
 
@@ -19,47 +19,41 @@ function extractOrgAndRepo(value: string) {
   return orgRepoString;
 }
 
+const FORMAT_ERROR = "Provide the repository as the format 'organization/repository'.";
+
 export default function useRepositoryField(defaultValue: string) {
   const [value, setValue] = useState<string>(defaultValue || "");
   const [error, setError] = useState<string>();
-  const [repoId, setRepoId] = useState<string>();
+
+  // Always derived from current value — no separate state, no blur needed
+  const repoId = extractOrgAndRepo(value.trim());
 
   useEffect(() => {
     if (defaultValue) {
-      // Automatically validate the value if the defaultValue is set
       onBlur();
     }
   }, [defaultValue]);
-
-  const validate = () => {
-    setError(undefined);
-    const orgRepoString = extractOrgAndRepo(value);
-
-    if (!orgRepoString) {
-      return "Provide the repository as the format 'organization/repository'.";
-    }
-  };
 
   const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
     setValue(e.target.value);
   }, []);
 
+  // Show format error without trimming — for use when a button is clicked before blur
+  const forceValidation = useCallback(() => {
+    setError(extractOrgAndRepo(value.trim()) ? undefined : FORMAT_ERROR);
+  }, [value]);
+
   const onBlur = useCallback(() => {
-    setRepoId(undefined);
-    const err = validate();
-    if (err) {
-      setError(err);
-    } else {
-      const trimmedValue = value.trim();
-      setRepoId(extractOrgAndRepo(trimmedValue));
-      setValue(trimmedValue);
-    }
+    const trimmedValue = value.trim();
+    setValue(trimmedValue);
+    setError(extractOrgAndRepo(trimmedValue) ? undefined : FORMAT_ERROR);
   }, [value]);
 
   return {
     repo: value,
     repoError: error,
     repoId,
+    forceValidation,
     repoFieldProps: {
       value,
       onChange,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { SpawnerFormProvider } from "./state";
 import Form from "./ProfileForm";
 import { FormCacheProvider } from "./context/FormCache";
+import { FormStateProvider } from "./context/FormState";
 import { PermalinkProvider } from "./context/Permalink";
 
 const root = createRoot(document.getElementById("form"));
@@ -9,7 +10,9 @@ root.render(
   <PermalinkProvider>
     <SpawnerFormProvider>
       <FormCacheProvider>
-        <Form />
+        <FormStateProvider>
+          <Form />
+        </FormStateProvider>
       </FormCacheProvider>
     </SpawnerFormProvider>
   </PermalinkProvider>

--- a/src/test/renderWithContext.tsx
+++ b/src/test/renderWithContext.tsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 
 import { SpawnerFormProvider } from "../state";
 import { FormCacheProvider } from "../context/FormCache";
+import { FormStateProvider } from "../context/FormState";
 import { PermalinkProvider } from "../context/Permalink";
 
 function renderWithContext(children: React.ReactNode) {
@@ -9,7 +10,9 @@ function renderWithContext(children: React.ReactNode) {
     <PermalinkProvider>
       <SpawnerFormProvider>
         <FormCacheProvider>
-          {children}
+          <FormStateProvider>
+            {children}
+          </FormStateProvider>
         </FormCacheProvider>
       </SpawnerFormProvider>
     </PermalinkProvider>

--- a/src/utils/formSubmit.ts
+++ b/src/utils/formSubmit.ts
@@ -1,0 +1,55 @@
+import { Dispatch, SetStateAction } from "react";
+
+export const collectFormErrors = (
+  form: HTMLFormElement,
+  setFormErrors: Dispatch<SetStateAction<Element[]>>,
+) => {
+  setTimeout(() => {
+    const errors = form.getElementsByClassName("invalid-feedback");
+    setFormErrors(Array.from(errors));
+  }, 10);
+  setTimeout(() => {
+    window.scrollTo(0, document.body.scrollHeight);
+  }, 100);
+};
+
+export const cacheFormValues = (
+  form: HTMLFormElement,
+  cacheChoiceOption: (fieldName: string, choice: string) => void,
+  cacheRepositorySelection: (fieldName: string, repository: string, ref: string) => void,
+) => {
+  const cacheUnlistedChoices = form.getElementsByClassName("cache-unlisted-choice");
+  Array.from(cacheUnlistedChoices).forEach((el) => {
+    const { id, value } = el as HTMLInputElement;
+    cacheChoiceOption(id, value);
+  });
+
+  const cacheRepositories = form.getElementsByClassName("cache-repository");
+  Array.from(cacheRepositories).forEach((el) => {
+    const { id, value } = el as HTMLInputElement;
+    if (id.endsWith("--repo")) {
+      const fieldName = id.slice(0, -6);
+      const refField = form.querySelector(`#${CSS.escape(`${fieldName}--ref`)}`);
+      if (refField) {
+        cacheRepositorySelection(fieldName, value, (refField as HTMLInputElement).value);
+      }
+    }
+  });
+};
+
+export const preBuildValidate = (form: HTMLFormElement): boolean => {
+  let firstInvalid: HTMLInputElement | null = null;
+  form.querySelectorAll<HTMLInputElement>("input, select, textarea").forEach((field) => {
+    // Hidden text input for dynamically buit image name (input is empty)
+    if (field.dataset.dynamicBuild === "true") return;
+    if (field.disabled) return;
+    if (!field.checkValidity()) {
+      if (!firstInvalid) firstInvalid = field;
+    }
+  });
+  if (firstInvalid) {
+    firstInvalid!.reportValidity();
+    return false;
+  }
+  return true;
+};

--- a/src/utils/formSubmit.ts
+++ b/src/utils/formSubmit.ts
@@ -40,7 +40,7 @@ export const cacheFormValues = (
 export const preBuildValidate = (form: HTMLFormElement): boolean => {
   let firstInvalid: HTMLInputElement | null = null;
   form.querySelectorAll<HTMLInputElement>("input, select, textarea").forEach((field) => {
-    // Hidden text input for dynamically buit image name (input is empty)
+    // Hidden text input for dynamically built image name
     if (field.dataset.dynamicBuild === "true") return;
     if (field.disabled) return;
     if (!field.checkValidity()) {

--- a/src/utils/formSubmit.ts
+++ b/src/utils/formSubmit.ts
@@ -4,10 +4,10 @@ export const collectFormErrors = (
   form: HTMLFormElement,
   setFormErrors: Dispatch<SetStateAction<Element[]>>,
 ) => {
-  setTimeout(() => {
+  queueMicrotask(() => {
     const errors = form.getElementsByClassName("invalid-feedback");
     setFormErrors(Array.from(errors));
-  }, 10);
+  });
   setTimeout(() => {
     window.scrollTo(0, document.body.scrollHeight);
   }, 100);


### PR DESCRIPTION
Close #153 

This PR restructures the code, fixes a few bugs.

### Architectural change
- This PR splits 'Start' button into two, start (taking form value and start) and build image and start (building image from form value and start). Before, `ProfileForm` component was doing both of the works, which required a lot of passing-ups of values& functionality from `ImageBuilder`. With this PR, the second button (Build and Start) now belongs to `ImageBuilder` component - ImageBuilder actually renders the button too, through [Portal](https://react.dev/reference/react-dom/createPortal) - since ImageBuilder is a child of ProfileForm, it needs Portal to 'send off' the component to its parent, but still controls its logic. 
- The ImageBuilder now needs some functionalities that ProfileForm used to submit the form. Those utilities are separated. It also needs to share some of its states with ProfileForm, these states went to the new context (`FormStateContext`)
- [x] Question: Is it better to rename the new context (FormStateContext) since it is more about ImageBuilder related context.? : Let's leave it since it is used outside of imagebuilder now.
- [x] Question (for myself): Is it better to delegate error check to html level pass it as `pattern` prop? : I will also leave it as it is now since the redundant regext needs to be used to extract repo and org name anyway.

### Bug Fixes
- The binderhub image build is requested even when org/repo name is not correctly structured. This PR brings the validation of the repo name prior to image build request, returning an error of wrong org/repo name before making a request. 
- Docker Image name was not getting validated (You can trigger Docker image build with an empty text input). This PR fixes it by passing pattern (html native validation) 

